### PR TITLE
Unify popover toggle and add preset buttons

### DIFF
--- a/components/generic/DateRange.vue
+++ b/components/generic/DateRange.vue
@@ -1,58 +1,71 @@
 <template>
   <client-only>
-    <div class="mb-4 flex w-full">
-      <v-date-picker
-        class="w-full"
-        :value="value"
-        :model-config="modelConfig"
-        :is24hr="true"
-        :popover="{ visibility: 'click' }"
-        mode="dateTime"
-        color="indigo"
-        is-range
-        v-on="$listeners"
-      >
-        <template #default="{ inputValue, inputEvents }">
-          <div class="flex flex-col sm:flex-row justify-start items-center h-full">
-            <div class="relative flex-grow w-full h-full">
-              <svg
-                class="text-gray-600 w-4 h-full mx-2 absolute pointer-events-none"
-                fill="none"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-              <input :class="textBoxClasses" :value="inputValue.start" v-on="inputEvents.start" />
+    <div class="mb-4">
+      <div class="flex mb-2 w-full">
+        <v-date-picker
+          class="w-full"
+          :value="value"
+          :model-config="modelConfig"
+          :is24hr="true"
+          :popover="{ visibility: 'hidden', placement: 'bottom' }"
+          :step="1"
+          mode="dateTime"
+          color="indigo"
+          is-range
+          v-on="$listeners"
+        >
+          <template #default="{ inputValue, inputEvents, showPopover }">
+            <div class="flex flex-row justify-start items-center h-full" @click="showPopover">
+              <div class="relative flex-grow w-full h-full">
+                <svg
+                  class="text-gray-600 w-4 h-full mx-2 absolute pointer-events-none"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  ></path>
+                </svg>
+                <input :class="textBoxClasses" :value="inputValue.start" v-on="inputEvents.start" />
+              </div>
+              <span class="flex-shrink-0 m-2">
+                <svg class="w-4 h-4 stroke-current text-gray-600" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+                </svg>
+              </span>
+              <div class="relative flex-grow w-full h-full">
+                <svg
+                  class="text-gray-600 w-4 h-full mx-2 absolute pointer-events-none"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  ></path>
+                </svg>
+                <input :class="textBoxClasses" :value="inputValue.end" v-on="inputEvents.end" />
+              </div>
             </div>
-            <span class="flex-shrink-0 m-2">
-              <svg class="w-4 h-4 stroke-current text-gray-600" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-              </svg>
-            </span>
-            <div class="relative flex-grow w-full h-full">
-              <svg
-                class="text-gray-600 w-4 h-full mx-2 absolute pointer-events-none"
-                fill="none"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-              <input :class="textBoxClasses" :value="inputValue.end" v-on="inputEvents.end" />
-            </div>
-          </div>
-        </template>
-      </v-date-picker>
-      <GenericButton colour="white" class="ml-2" @click="$emit('input', { since: null, until: null })"
-        >Clear</GenericButton
-      >
+          </template>
+        </v-date-picker>
+        <GenericButton colour="white" class="ml-2" @click="$emit('input', { start: null, end: null })"
+          >Clear</GenericButton
+        >
+      </div>
+      <div class="flex gap-2">
+        <GenericButtonMini @click="setLastNDays(7)"><TextP>Last 7 days</TextP></GenericButtonMini>
+        <GenericButtonMini @click="setLastNDays(30)"><TextP>Last 30 days</TextP></GenericButtonMini>
+        <GenericButtonMini @click="setLastNDays(365)"><TextP>Last year</TextP></GenericButtonMini>
+        <GenericButtonMini @click="setLastNDays(3650)"><TextP>Last 10 years</TextP></GenericButtonMini>
+      </div>
     </div>
   </client-only>
 </template>
@@ -60,7 +73,7 @@
 <script lang="ts">
 import { defineComponent } from '@nuxtjs/composition-api'
 
-import { DateRange } from '@/utilities/dateUtils'
+import { DateRange, nowString } from '@/utilities/dateUtils'
 
 export default defineComponent({
   props: {
@@ -83,11 +96,16 @@ export default defineComponent({
       }),
     },
   },
-  setup() {
+  setup(_, { emit }) {
     const textBoxClasses =
-      'flex-grow pl-8 pr-2 py-1 w-full h-full bg-white border border-gray-300 rounded-md placeholder-gray-500 focus:outline-none focus:text-gray-900 focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500'
+      'flex-grow pl-8 pr-2 py-1 w-full h-full bg-white border border-gray-300 rounded-md placeholder-gray-500 focus:outline-none focus:text-gray-900 focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 truncate'
 
-    return { textBoxClasses }
+    function setLastNDays(daysAgo: number): void {
+      const newRange: DateRange = { start: nowString(-daysAgo), end: nowString(0) }
+      emit('input', newRange)
+    }
+
+    return { textBoxClasses, setLastNDays }
   },
 })
 </script>


### PR DESCRIPTION
Due to (I think) limitations of v-calendar, I can't get separate instances of the popover per textbox, so instead I've made 2 changes:

1. Clicking anywhere on the input line triggers the same, single instance of the popover, centered on the whole line. This makes it much clearer than both text boxes map onto the same popover.
2. Added preset range buttons, so most of the time you won't even need to go into the input boxes.
