### PR TITLE
Rename "errors" to "messages"

### DIFF
--- a/components/errors/ListItem.vue
+++ b/components/errors/ListItem.vue
@@ -29,7 +29,7 @@
       <div class="flex items-center gap-4 col-span-3 lg:col-span-1">
         <GenericButtonRound
           v-if="showPatientFilter"
-          :to="{ path: '/errors', query: { nationalid: item.ni } }"
+          :to="{ path: '/messages', query: { nationalid: item.ni } }"
           tooltip="Filter errors by this patient"
           ><IconMiniFilter
         /></GenericButtonRound>
@@ -47,7 +47,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@nuxtjs/composition-api'
 import { formatDate } from '@/utilities/dateUtils'
-import { Message } from '@/interfaces/errors'
+import { Message } from '@/interfaces/messages'
 
 export default defineComponent({
   props: {

--- a/components/errors/MiniList.vue
+++ b/components/errors/MiniList.vue
@@ -6,7 +6,7 @@
     </GenericCardHeader>
     <ul class="divide-y divide-gray-200">
       <div v-for="item in relatedErrors" :key="item.id" :item="item" class="hover:bg-gray-50">
-        <NuxtLink :to="`/errors/${item.id}`">
+        <NuxtLink :to="`/messages/${item.id}`">
           <ErrorsListItem :item="item" />
         </NuxtLink>
       </div>
@@ -24,7 +24,7 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, ref, useContext, watch } from '@nuxtjs/composition-api'
-import { Message } from '~/interfaces/errors'
+import { Message } from '@/interfaces/messages'
 
 export default defineComponent({
   props: {

--- a/components/errors/MiniList.vue
+++ b/components/errors/MiniList.vue
@@ -60,8 +60,8 @@ export default defineComponent({
 
     async function updateRelatedErrors(): Promise<void> {
       let path = props.errorsUrl + `?page=${relatedErrorsPage.value}&size=${relatedErrorsSize.value}`
-      if (status) {
-        path = path + `&status=${status}`
+      if (props.status) {
+        path = path + `&status=${props.status}`
       }
       const res = await $axios.$get(path)
       // Set related errors

--- a/components/errors/StatusBadge.vue
+++ b/components/errors/StatusBadge.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts">
 import { computed, defineComponent } from '@nuxtjs/composition-api'
-import { Message } from '@/interfaces/errors'
+import { Message } from '@/interfaces/messages'
 
 export default defineComponent({
   props: {

--- a/components/navigation/Sidebar.vue
+++ b/components/navigation/Sidebar.vue
@@ -129,8 +129,8 @@ export default defineComponent({
         visible:
           hasPermission('ukrdc:workitems:read') ||
           hasPermission('ukrdc:workitems:write') ||
-          hasPermission('ukrdc:errors:read') ||
-          hasPermission('ukrdc:errors:write'),
+          hasPermission('ukrdc:messages:read') ||
+          hasPermission('ukrdc:messages:write'),
       },
       {
         title: 'EMPI',
@@ -146,9 +146,9 @@ export default defineComponent({
       },
       {
         title: 'Errors',
-        url: '/errors',
+        url: '/messages',
         svg: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
-        visible: hasPermission('ukrdc:errors:read') || hasPermission('ukrdc:errors:write'),
+        visible: hasPermission('ukrdc:messages:read') || hasPermission('ukrdc:messages:write'),
       },
       {
         title: 'System',

--- a/interfaces/messages.ts
+++ b/interfaces/messages.ts
@@ -1,4 +1,4 @@
-interface ErrorLinks {
+interface MessageLinks {
   self: string
   mirth: string
   workitems: string
@@ -21,7 +21,7 @@ export interface Message extends MinimalMessage {
   error: string
   status: string
   msgStatus: string
-  links: ErrorLinks
+  links: MessageLinks
 }
 
 export interface ErrorSource {

--- a/pages/masterrecords/_id/index.vue
+++ b/pages/masterrecords/_id/index.vue
@@ -106,7 +106,7 @@ import { isTracing } from '@/utilities/recordUtils'
 
 import { MasterRecord, MasterRecordStatistics } from '@/interfaces/masterrecord'
 import { PatientRecord } from '@/interfaces/patientrecord'
-import { MinimalMessage } from '~/interfaces/errors'
+import { MinimalMessage } from '~/interfaces/messages'
 
 export default defineComponent({
   props: {

--- a/pages/masterrecords/_id/issues.vue
+++ b/pages/masterrecords/_id/issues.vue
@@ -22,7 +22,7 @@
       v-if="record && record.links"
       class="my-4"
       title="Record Errors"
-      :errors-url="record.links.errors"
+      :errors-url="record.links.messages"
     />
   </div>
 </template>

--- a/pages/masterrecords/_id/messages.vue
+++ b/pages/masterrecords/_id/messages.vue
@@ -21,7 +21,7 @@
       <!-- Real results -->
       <ul v-else class="divide-y divide-gray-200">
         <div v-for="item in messages" :key="item.id" :item="item" class="hover:bg-gray-50">
-          <NuxtLink :to="`/errors/${item.id}`">
+          <NuxtLink :to="`/messages/${item.id}`">
             <ErrorsListItem :show-patient-filter="false" :item="item" />
           </NuxtLink>
         </div>
@@ -41,7 +41,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, useContext, useFetch, useRoute, watch } from '@nuxtjs/composition-api'
-import { Message } from '~/interfaces/errors'
+import { Message } from '~/interfaces/messages'
 import { MasterRecord, MasterRecordStatistics } from '~/interfaces/masterrecord'
 import usePagination from '~/mixins/usePagination'
 import useSortBy from '~/mixins/useSortBy'

--- a/pages/messages/_id.vue
+++ b/pages/messages/_id.vue
@@ -119,7 +119,7 @@
 <script lang="ts">
 import { defineComponent, ref, useRoute, useFetch, useContext, useMeta } from '@nuxtjs/composition-api'
 
-import { Message, ErrorSource } from '@/interfaces/errors'
+import { Message, ErrorSource } from '@/interfaces/messages'
 import { ChannelMessage } from '@/interfaces/mirth'
 import { MasterRecord } from '@/interfaces/masterrecord'
 import { WorkItemShort } from '@/interfaces/workitem'
@@ -152,7 +152,7 @@ export default defineComponent({
 
     useFetch(async () => {
       // Get the main record data
-      const path = `${$config.apiBase}/v1/errors/messages/${route.value.params.id}/`
+      const path = `${$config.apiBase}/v1/messages/${route.value.params.id}/`
       const res: Message = await $axios.$get(path)
       error.value = res
 

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -38,7 +38,7 @@
       <!-- Real results -->
       <ul v-else class="divide-y divide-gray-200">
         <div v-for="item in messages" :key="item.id" :item="item" class="hover:bg-gray-50">
-          <NuxtLink :to="`/errors/${item.id}`">
+          <NuxtLink :to="`/messages/${item.id}`">
             <ErrorsListItem :item="item" />
           </NuxtLink>
         </div>
@@ -63,7 +63,7 @@ import usePagination from '@/mixins/usePagination'
 import useDateRange from '@/mixins/useDateRange'
 import { nowString } from '@/utilities/dateUtils'
 
-import { Message } from '@/interfaces/errors'
+import { Message } from '@/interfaces/messages'
 import useFacilities from '~/mixins/useFacilities'
 import useQuery from '~/mixins/useQuery'
 import useSortBy from '~/mixins/useSortBy'
@@ -96,7 +96,7 @@ export default defineComponent({
 
     const { fetch } = useFetch(async () => {
       // Fetch the dashboard response from our API server
-      let path = `${$config.apiBase}/v1/errors/messages/?status=ERROR&page=${page.value}&size=${size.value}&sort_by=received&order_by=${orderBy.value}`
+      let path = `${$config.apiBase}/v1/messages/?status=ERROR&page=${page.value}&size=${size.value}&sort_by=received&order_by=${orderBy.value}`
       // Filter by since if it exists
       if (dateRange.value.start) {
         path = path + `&since=${dateRange.value.start}`


### PR DESCRIPTION
Depends on https://github.com/renalreg/ukrdc-fastapi/pull/132

More and more now we're using the errorsdb as a general log of incoming and stored messages, with errors being a subset. This should be reflected in the API and code structure.

This PR basically renamed a bunch of "error" resources to "messages", and removes some redundant API routes, replacing them with generic routes with optional ERROR filters.