### PR TITLE
Move slower pages to client-side fetching only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ For detailed explanation on how things work, check out [Nuxt.js docs](https://nu
 
 ## Developer notes
 
+### Server-side fetching
+
+In order to enable runtime-configueration, we make use of Nuxt server-side rendering. However, on some pages we want data fetching to always happen client-side. This is usually for pages where mutliple API routes are called, populating the page in "chunks". Usually, we don't want the user to have to wait for every chunk to finish before showing anything (as is the case with server-side fetching), so for these pages we set `fetchOnServer: false`. Now, the server will render the DOM, send this to the client, and the client will then call the API to populate page data.
+
+A primary example of this is when viewing a Master Record. While most record data laods quickly, some queries such as finding related records and messages take longer to run. We want to show the user all data as soon as it's available, so we enforce client-side fetching to allow this.
+
+Similarly, some API routes slow down occasionally due to upstream load, e.g. Mirth message information. We'd rather show users that the data is being loaded rather than just hanging waiting for the page to load at all. By moving fetching to the client-side we can render loading messages/animations and handle timeouts more gracefully.
+
 ### Framework rationale
 
 #### Vue

--- a/pages/masterrecords/_id.vue
+++ b/pages/masterrecords/_id.vue
@@ -38,6 +38,8 @@ import { MasterRecord, MasterRecordStatistics } from '@/interfaces/masterrecord'
 import { TabItem } from '@/interfaces/tabs'
 
 export default defineComponent({
+  fetchOnServer: false,
+
   setup() {
     const route = useRoute()
     const { $axios, $config } = useContext()

--- a/pages/messages/_id.vue
+++ b/pages/messages/_id.vue
@@ -131,6 +131,8 @@ import { modalInterface } from '~/interfaces/modal'
 import usePermissions from '~/mixins/usePermissions'
 
 export default defineComponent({
+  fetchOnServer: false,
+
   setup() {
     const route = useRoute()
     const { $axios, $config } = useContext()

--- a/pages/mirth/messages/_channel/_id.vue
+++ b/pages/mirth/messages/_channel/_id.vue
@@ -21,6 +21,8 @@ import { ChannelMessage } from '@/interfaces/mirth'
 import { isEmptyObject } from '@/utilities/objectUtils'
 
 export default defineComponent({
+  fetchOnServer: false,
+
   setup() {
     const route = useRoute()
     const { $axios, $config } = useContext()

--- a/pages/patientrecords/_pid.vue
+++ b/pages/patientrecords/_pid.vue
@@ -40,6 +40,8 @@ import { isMembership } from '@/utilities/recordUtils'
 import usePermissions from '~/mixins/usePermissions'
 
 export default defineComponent({
+  fetchOnServer: false,
+
   setup() {
     const route = useRoute()
     const router = useRouter()

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -228,6 +228,8 @@ interface AvailableActions {
 }
 
 export default defineComponent({
+  fetchOnServer: false,
+
   setup() {
     // Dependencies
     const route = useRoute()


### PR DESCRIPTION
In order to enable runtime-configueration, we make use of Nuxt server-side rendering. However, on some pages we want data fetching to always happen client-side. This is usually for pages where mutliple API routes are called, populating the page in "chunks". Usually, we don't want the user to have to wait for every chunk to finish before showing anything (as is the case with server-side fetching), so for these pages we set `fetchOnServer: false`. Now, the server will render the DOM, send this to the client, and the client will then call the API to populate page data.

A primary example of this is when viewing a Master Record. While most record data laods quickly, some queries such as finding related records and messages take longer to run. We want to show the user all data as soon as it's available, so we enforce client-side fetching to allow this.

Similarly, some API routes slow down occasionally due to upstream load, e.g. Mirth message information. We'd rather show users that the data is being loaded rather than just hanging waiting for the page to load at all. By moving fetching to the client-side we can render loading messages/animations and handle timeouts more gracefully.