### PR TITLE
Added basic record manage menu

### DIFF
--- a/components/errors/ListItem.vue
+++ b/components/errors/ListItem.vue
@@ -13,7 +13,7 @@
         </div>
         <div class="mt-2 flex">
           <ErrorsStatusBadge class="flex-shrink mr-2" :message="item" />
-          <TextP class="flex-grow line-clamp-2">
+          <TextP class="flex-grow line-clamp-1">
             {{ itemDescription }}
           </TextP>
         </div>
@@ -31,6 +31,7 @@
           v-if="showPatientFilter"
           :to="{ path: '/messages', query: { nationalid: item.ni } }"
           tooltip="Filter errors by this patient"
+          :label="`Filter errors by patient ${item.ni}`"
           ><IconMiniFilter
         /></GenericButtonRound>
         <div class="flex-grow">

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -3,7 +3,9 @@
     <input
       v-model="proxyChecked"
       class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 mr-2 rounded"
+      :class="{ 'opacity-50': disabled }"
       type="checkbox"
+      :disabled="disabled"
       :value="value"
     />
     {{ label }}
@@ -30,6 +32,11 @@ export default {
       type: [String, Number, Boolean],
       required: false,
       default: null,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   computed: {

--- a/components/generic/Blackout.vue
+++ b/components/generic/Blackout.vue
@@ -1,0 +1,27 @@
+<template>
+  <transition
+    enter-active-class="ease-out"
+    enter-class="opacity-0"
+    enter-to-class="opacity-100"
+    leave-active-class="ease-in"
+    leave-class="opacity-100"
+    leave-to-class="opacity-0 scale-90"
+  >
+    <div v-if="visible" class="fixed inset-0 transition-opacity" aria-hidden="true" @click="$emit('click')">
+      <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  props: {
+    visible: {
+      type: Boolean,
+      required: true,
+    },
+  },
+})
+</script>

--- a/components/generic/Button.vue
+++ b/components/generic/Button.vue
@@ -1,10 +1,25 @@
 <template>
   <router-link v-if="to" v-slot="{ navigate }" custom :to="to">
-    <button v-tooltip="tooltip" :aria-label="label" type="button" :class="`btn-${colour}`" @click="navigate">
+    <button
+      v-tooltip="tooltip"
+      :aria-label="label"
+      type="button"
+      :disabled="disabled"
+      :class="[`btn-${colour}`, disabled ? 'btn-disabled' : '']"
+      @click="navigate"
+    >
       <slot />
     </button>
   </router-link>
-  <button v-else v-tooltip="tooltip" :aria-label="label" type="button" :class="`btn-${colour}`" @click="$emit('click')">
+  <button
+    v-else
+    v-tooltip="tooltip"
+    :aria-label="label"
+    type="button"
+    :disabled="disabled"
+    :class="[`btn-${colour}`, { 'btn-disabled': disabled }]"
+    @click="$emit('click')"
+  >
     <slot />
   </button>
 </template>
@@ -32,11 +47,19 @@ export default {
       required: false,
       default: null,
     },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 }
 </script>
 
 <style lang="postcss">
+.btn-disabled {
+  @apply opacity-50 cursor-default;
+}
 .btn-white {
   @apply btn-base bg-white hover:bg-gray-50 focus:ring-indigo-500 border-gray-300 text-gray-700;
 }

--- a/components/generic/Button.vue
+++ b/components/generic/Button.vue
@@ -1,10 +1,10 @@
 <template>
   <router-link v-if="to" v-slot="{ navigate }" custom :to="to">
-    <button v-tooltip="tooltip" type="button" :class="`btn-${colour}`" @click="navigate">
+    <button v-tooltip="tooltip" :aria-label="label" type="button" :class="`btn-${colour}`" @click="navigate">
       <slot />
     </button>
   </router-link>
-  <button v-else v-tooltip="tooltip" type="button" :class="`btn-${colour}`" @click="$emit('click')">
+  <button v-else v-tooltip="tooltip" :aria-label="label" type="button" :class="`btn-${colour}`" @click="$emit('click')">
     <slot />
   </button>
 </template>
@@ -23,6 +23,11 @@ export default {
       default: 'white',
     },
     tooltip: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    label: {
       type: String,
       required: false,
       default: null,

--- a/components/generic/Menu.vue
+++ b/components/generic/Menu.vue
@@ -1,0 +1,49 @@
+<template>
+  <transition
+    enter-active-class="transition-all transition-fast ease-out"
+    enter-class="opacity-0 scale-95"
+    enter-to-class="opacity-100 scale-100"
+    leave-active-class="transition-all transition-fastest ease-in"
+    leave-class="opacity-100 scale-100"
+    leave-to-class="opacity-0 scale-95"
+  >
+    <div
+      v-show="show"
+      class="
+        origin-top-right
+        absolute
+        right-0
+        mx-2
+        my-2
+        w-56
+        rounded-md
+        shadow-lg
+        bg-white
+        ring-1 ring-black ring-opacity-5
+        focus:outline-none
+      "
+      role="menu"
+      aria-orientation="vertical"
+      aria-labelledby="option-menu-button"
+      tabindex="-1"
+    >
+      <div class="py-1" role="none">
+        <slot></slot>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  props: {
+    show: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+})
+</script>

--- a/components/generic/MenuItem.vue
+++ b/components/generic/MenuItem.vue
@@ -1,0 +1,31 @@
+<template>
+  <span class="block px-4 py-2 text-sm" :class="classes" role="menuitem" tabindex="-1">
+    <slot></slot>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  props: {
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+
+  setup(props) {
+    const classes = computed(() => {
+      if (props.disabled) {
+        return ['text-gray-400']
+      } else {
+        return ['text-gray-700', 'hover:bg-gray-100', 'hover:text-gray-900', 'cursor-pointer']
+      }
+    })
+
+    return { classes }
+  },
+})
+</script>

--- a/components/generic/SearchableSelect.vue
+++ b/components/generic/SearchableSelect.vue
@@ -2,18 +2,7 @@
   <transition :duration="200">
     <div class="relative">
       <!-- Background overlay, show/hide based on modal state. -->
-      <transition
-        enter-active-class="ease-out"
-        enter-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="ease-in"
-        leave-class="opacity-100"
-        leave-to-class="opacity-0 scale-90"
-      >
-        <div v-if="isOpen && closable" class="fixed inset-0 transition-opacity" aria-hidden="true" @click="cancel()">
-          <div class="absolute inset-0 bg-gray-500 opacity-10"></div>
-        </div>
-      </transition>
+      <GenericBlackout :visible="closable && isOpen" @click="cancel()" />
 
       <!-- Main component -->
       <div class="flex w-full">

--- a/components/generic/button/Mini.vue
+++ b/components/generic/button/Mini.vue
@@ -1,10 +1,17 @@
 <template>
   <router-link v-if="to" v-slot="{ navigate }" custom :to="to">
-    <button v-tooltip="tooltip" type="button" :class="`btn-mini-${colour}`" @click="navigate">
+    <button v-tooltip="tooltip" :aria-label="label" type="button" :class="`btn-mini-${colour}`" @click="navigate">
       <slot />
     </button>
   </router-link>
-  <button v-else v-tooltip="tooltip" type="button" :class="`btn-mini-${colour}`" @click="$emit('click')">
+  <button
+    v-else
+    v-tooltip="tooltip"
+    :aria-label="label"
+    type="button"
+    :class="`btn-mini-${colour}`"
+    @click="$emit('click')"
+  >
     <slot />
   </button>
 </template>
@@ -24,6 +31,11 @@ export default defineComponent({
       default: 'white',
     },
     tooltip: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    label: {
       type: String,
       required: false,
       default: null,

--- a/components/generic/button/Round.vue
+++ b/components/generic/button/Round.vue
@@ -1,10 +1,10 @@
 <template>
   <router-link v-if="to" v-slot="{ navigate }" custom :to="to">
-    <button v-tooltip="tooltip" type="button" class="btn-round-base" @click="navigate">
+    <button v-tooltip="tooltip" :aria-label="label" type="button" class="btn-round-base" @click="navigate">
       <slot />
     </button>
   </router-link>
-  <button v-else v-tooltip="tooltip" type="button" class="btn-round-base" @click="$emit('click')">
+  <button v-else v-tooltip="tooltip" :aria-label="label" type="button" class="btn-round-base" @click="$emit('click')">
     <slot />
   </button>
 </template>
@@ -20,6 +20,11 @@ export default defineComponent({
       default: null,
     },
     tooltip: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    label: {
       type: String,
       required: false,
       default: null,

--- a/components/generic/modal/MaxSlot.vue
+++ b/components/generic/modal/MaxSlot.vue
@@ -3,14 +3,7 @@
     <div v-show="visible" class="fixed z-10 inset-0">
       <div class="items-end justify-center h-screen w-screen block p-0 mt-16 md:mt-0">
         <!-- Modal panel, show/hide based on modal state. -->
-        <transition
-          enter-active-class="ease-out"
-          enter-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          enter-to-class="opacity-100 translate-y-0 sm:scale-100"
-          leave-active-class="ease-in"
-          leave-class="opacity-100 translate-y-0 sm:scale-100"
-          leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-        >
+        <TransitionModal>
           <div
             v-show="visible"
             class="inline-block align-bottom vibrancy shadow-xl transform transition-all sm:align-middle h-full w-full"
@@ -45,7 +38,7 @@
             </div>
             <slot></slot>
           </div>
-        </transition>
+        </TransitionModal>
       </div>
     </div>
   </transition>

--- a/components/generic/modal/Slot.vue
+++ b/components/generic/modal/Slot.vue
@@ -3,30 +3,12 @@
     <div v-show="visible" class="fixed z-10 inset-0 overflow-y-auto">
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0 mt-16 md:mt-0">
         <!-- Background overlay, show/hide based on modal state. -->
-        <transition
-          enter-active-class="ease-out"
-          enter-class="opacity-0"
-          enter-to-class="opacity-100"
-          leave-active-class="ease-in"
-          leave-class="opacity-100"
-          leave-to-class="opacity-0 scale-90"
-        >
-          <div v-if="visible" class="fixed inset-0 transition-opacity" aria-hidden="true" @click="hide()">
-            <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
-          </div>
-        </transition>
+        <GenericBlackout :visible="visible" @click="hide()" />
 
         <!-- This element is to trick the browser into centering the modal contents. -->
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         <!-- Modal panel, show/hide based on modal state. -->
-        <transition
-          enter-active-class="ease-out"
-          enter-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          enter-to-class="opacity-100 translate-y-0 sm:scale-100"
-          leave-active-class="ease-in"
-          leave-class="opacity-100 translate-y-0 sm:scale-100"
-          leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-        >
+        <TransitionModal>
           <div
             v-show="visible"
             class="
@@ -50,7 +32,7 @@
           >
             <slot></slot>
           </div>
-        </transition>
+        </TransitionModal>
       </div>
     </div>
   </transition>

--- a/components/patientrecords/DeleteModal.vue
+++ b/components/patientrecords/DeleteModal.vue
@@ -274,6 +274,7 @@ export default defineComponent({
     }
 
     watch(visible, async () => {
+      // If the modal becomes visible
       if (visible.value) {
         // Reset the modal each time it's is shown.
         confirmChecked.value = false
@@ -281,11 +282,13 @@ export default defineComponent({
         deleteResponse.value = undefined
 
         try {
+          // Fetch the delete preview and confirmation hash
           const res: DeletePIDResponseSchema = await $axios.$post(
             `${$config.apiBase}/v1/patientrecords/${props.item.pid}/delete`
           )
           previewResponse.value = res
         } catch (error) {
+          // Populate error message if preview fails
           if (error.response.status === 400) {
             console.log(error.response.data.detail)
             previewErrorMessage.value = error.response.data.detail
@@ -295,20 +298,29 @@ export default defineComponent({
     })
 
     async function doRealDelete() {
+      // Emit confirm event (currently unused)
       emit('confirm')
+      // If the checkbox is checked and we have a preview response
       if (confirmChecked.value && previewResponse.value) {
+        // Start the delete spinner
         deleteInProgress.value = true
+        // Request an actual delete by sending the confirmation hash
         const res: DeletePIDResponseSchema = await $axios.$post(
           `${$config.apiBase}/v1/patientrecords/${props.item.pid}/delete`,
           {
             hash: previewResponse.value.hash,
           }
         )
+        // Populate the updated preview (currently unused)
         previewResponse.value = res
       }
+      // Remove the delete spinner
       deleteInProgress.value = false
+      // Hide the modal
       hide()
+      // Emit an event notifying parents that a record has been deleted
       emit('deleted')
+      // Show success toast
       $toast.show({
         type: 'success',
         title: 'Success',

--- a/components/patientrecords/DeleteModal.vue
+++ b/components/patientrecords/DeleteModal.vue
@@ -8,14 +8,7 @@
         <!-- This element is to trick the browser into centering the modal contents. -->
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         <!-- Modal panel, show/hide based on modal state. -->
-        <transition
-          enter-active-class="ease-out"
-          enter-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          enter-to-class="opacity-100 translate-y-0 sm:scale-100"
-          leave-active-class="ease-in"
-          leave-class="opacity-100 translate-y-0 sm:scale-100"
-          leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-        >
+        <TransitionModal>
           <div
             v-show="visible"
             class="
@@ -40,6 +33,7 @@
             <div class="sm:flex sm:items-start">
               <div
                 class="
+                  bg-red-100
                   mx-auto
                   flex-shrink-0 flex
                   items-center
@@ -49,95 +43,57 @@
                   rounded-full
                   sm:mx-0 sm:h-10 sm:w-10
                 "
-                :class="danger ? 'bg-red-100' : 'bg-indigo-100'"
               >
                 <!-- Heroicon name: outline/exclamation -->
                 <svg
-                  class="h-6 w-6"
-                  :class="danger ? 'text-red-600' : 'text-indigo-600'"
+                  class="text-red-600 h-6 w-6"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
                   aria-hidden="true"
                 >
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="modalIcon" />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
                 </svg>
               </div>
               <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                <h3 id="modal-headline" class="text-lg leading-6 font-medium text-gray-900">
-                  {{ title }}
-                </h3>
+                <h3 id="modal-headline" class="text-lg leading-6 font-medium text-gray-900">Delete patient record?</h3>
                 <div class="mt-2">
-                  <p class="text-gray-500">
-                    {{ message }}
-                  </p>
+                  <p class="text-gray-500">MESSAGE</p>
                 </div>
               </div>
             </div>
             <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-              <GenericButton class="ml-2" :colour="danger ? 'red' : 'indigo'" @click="confirm()">
-                {{ confirmLabel }}
-              </GenericButton>
-              <GenericButton @click="cancel()">
-                {{ cancelLabel }}
-              </GenericButton>
+              <GenericButton class="ml-2" colour="red" @click="confirm()"> Delete </GenericButton>
+              <GenericButton @click="cancel()"> Cancel </GenericButton>
             </div>
           </div>
-        </transition>
+        </TransitionModal>
       </div>
     </div>
   </transition>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@nuxtjs/composition-api'
+import { defineComponent } from '@nuxtjs/composition-api'
 import useModal from '@/mixins/useModal'
+import { PatientRecord } from '~/interfaces/patientrecord'
 
 export default defineComponent({
   props: {
-    title: {
-      type: String,
+    item: {
+      type: Object as () => PatientRecord,
       required: true,
-    },
-    message: {
-      type: String,
-      required: true,
-    },
-    confirmLabel: {
-      type: String,
-      required: false,
-      default: 'Confirm',
-    },
-    cancelLabel: {
-      type: String,
-      required: false,
-      default: 'Cancel',
-    },
-    danger: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    icon: {
-      type: String,
-      required: false,
-      default: null,
     },
   },
 
-  setup(props, { emit }) {
+  setup(_, { emit }) {
     const { visible, show, hide, toggle } = useModal()
-
-    const modalIcon = computed(() => {
-      if (props.icon !== null) {
-        return props.icon
-      } else if (props.danger) {
-        return 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
-      } else {
-        return 'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
-      }
-    })
 
     function confirm(): void {
       emit('confirm')
@@ -150,7 +106,6 @@ export default defineComponent({
 
     return {
       visible,
-      modalIcon,
       confirm,
       cancel,
       show,

--- a/components/patientrecords/GroupedList.vue
+++ b/components/patientrecords/GroupedList.vue
@@ -3,27 +3,52 @@
     <div v-if="groupedRecords.data.length > 0" class="bg-gray-50 pl-4 sm:pl-6 py-1">
       <TextH4>Data feeds</TextH4>
     </div>
-    <patientrecordsListItem v-for="item in groupedRecords.data" :key="item.pid + '_data'" :item="item" />
+    <patientrecordsListItem
+      v-for="item in groupedRecords.data"
+      :key="item.pid + '_data'"
+      :item="item"
+      @deleted="$emit('refresh')"
+    />
 
     <div v-if="groupedRecords.surveys.length > 0" class="bg-gray-50 pl-4 sm:pl-6 py-1">
       <TextH4>Survey feeds</TextH4>
     </div>
-    <patientrecordsListItem v-for="item in groupedRecords.surveys" :key="item.pid + '_survey'" :item="item" />
+    <patientrecordsListItem
+      v-for="item in groupedRecords.surveys"
+      :key="item.pid + '_survey'"
+      :item="item"
+      @deleted="$emit('refresh')"
+    />
 
     <div v-if="groupedRecords.migrated.length > 0" class="bg-gray-50 pl-4 sm:pl-6 py-1">
       <TextH4>Historic Migrated Data</TextH4>
     </div>
-    <patientrecordsListItem v-for="item in groupedRecords.migrated" :key="item.pid + '_mig'" :item="item" />
+    <patientrecordsListItem
+      v-for="item in groupedRecords.migrated"
+      :key="item.pid + '_mig'"
+      :item="item"
+      @deleted="$emit('refresh')"
+    />
 
     <div v-if="groupedRecords.memberships.length > 0" class="bg-gray-50 pl-4 sm:pl-6 py-1">
       <TextH4>Membership Records</TextH4>
     </div>
-    <patientrecordsListItem v-for="item in groupedRecords.memberships" :key="item.pid + '_membership'" :item="item" />
+    <patientrecordsListItem
+      v-for="item in groupedRecords.memberships"
+      :key="item.pid + '_membership'"
+      :item="item"
+      @deleted="$emit('refresh')"
+    />
 
     <div v-if="groupedRecords.tracing.length > 0" class="bg-gray-50 pl-4 sm:pl-6 py-1">
       <TextH4>Tracing Records</TextH4>
     </div>
-    <patientrecordsListItem v-for="item in groupedRecords.tracing" :key="item.pid + '_tracing'" :item="item" />
+    <patientrecordsListItem
+      v-for="item in groupedRecords.tracing"
+      :key="item.pid + '_tracing'"
+      :item="item"
+      @deleted="$emit('refresh')"
+    />
   </ul>
 </template>
 

--- a/components/patientrecords/ListItem.vue
+++ b/components/patientrecords/ListItem.vue
@@ -34,21 +34,10 @@
             </TextP>
           </div>
           <!-- Record links -->
-          <div v-click-away="closeMenu" class="justify-self-end flex items-center">
+          <div class="justify-self-end flex items-center">
             <GenericButtonMini :to="`/patientrecords/${item.pid}`" class="h-8">View Record</GenericButtonMini>
-            <GenericButtonMini
-              label="Manage record"
-              tooltip="Manage Record"
-              class="h-8 ml-1"
-              @click="showMenu = !showMenu"
-            >
-              <IconChevronDown />
-            </GenericButtonMini>
+            <PatientrecordsManageMenu :item="item" />
           </div>
-          <GenericMenu class="mt-8" :show="showMenu">
-            <GenericMenuItem @click.native="copyPID"> Copy PID </GenericMenuItem>
-            <GenericMenuItem :disabled="true"> Delete Record </GenericMenuItem>
-          </GenericMenu>
         </div>
       </div>
     </div>
@@ -60,7 +49,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, useContext } from '@nuxtjs/composition-api'
+import { defineComponent, ref } from '@nuxtjs/composition-api'
 import { formatDate } from '@/utilities/dateUtils'
 import { PatientRecord } from '@/interfaces/patientrecord'
 
@@ -71,30 +60,9 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
-    const { $toast } = useContext()
-
+  setup() {
     const showDetail = ref(false)
-    const showMenu = ref(false)
-
-    function closeMenu() {
-      showMenu.value = false
-    }
-
-    function copyPID() {
-      navigator.clipboard.writeText(props.item.pid).then(() => {
-        closeMenu()
-        $toast.show({
-          type: 'success',
-          title: 'Success',
-          message: 'PID copied to clipboard',
-          timeout: 5,
-          classTimeout: 'bg-green-600',
-        })
-      })
-    }
-
-    return { showDetail, showMenu, closeMenu, copyPID, formatDate }
+    return { showDetail, formatDate }
   },
 })
 </script>

--- a/components/patientrecords/ListItem.vue
+++ b/components/patientrecords/ListItem.vue
@@ -3,6 +3,8 @@
     <div class="flex items-center py-4">
       <div class="min-w-0 flex-1 flex items-center">
         <div
+          v-tooltip="'Show Details'"
+          aria-label="Show details"
           class="flex flex-none items-center justify-center w-16 self-stretch cursor-pointer"
           @click="showDetail = !showDetail"
         >
@@ -34,7 +36,14 @@
           <!-- Record links -->
           <div v-click-away="closeMenu" class="justify-self-end flex items-center">
             <GenericButtonMini :to="`/patientrecords/${item.pid}`" class="h-8">View Record</GenericButtonMini>
-            <GenericButtonMini class="h-8 ml-1" @click="showMenu = !showMenu"><IconChevronDown /></GenericButtonMini>
+            <GenericButtonMini
+              label="Manage record"
+              tooltip="Manage Record"
+              class="h-8 ml-1"
+              @click="showMenu = !showMenu"
+            >
+              <IconChevronDown />
+            </GenericButtonMini>
           </div>
           <GenericMenu class="mt-8" :show="showMenu">
             <GenericMenuItem @click.native="copyPID"> Copy PID </GenericMenuItem>

--- a/components/patientrecords/ListItem.vue
+++ b/components/patientrecords/ListItem.vue
@@ -36,7 +36,7 @@
           <!-- Record links -->
           <div class="justify-self-end flex items-center">
             <GenericButtonMini :to="`/patientrecords/${item.pid}`" class="h-8">View Record</GenericButtonMini>
-            <PatientrecordsManageMenu :item="item" />
+            <PatientrecordsManageMenu :item="item" @deleted="$emit('deleted')" />
           </div>
         </div>
       </div>

--- a/components/patientrecords/ListItem.vue
+++ b/components/patientrecords/ListItem.vue
@@ -31,10 +31,15 @@
               {{ item.ukrdcid }}
             </TextP>
           </div>
-          <!-- Record link -->
-          <GenericButtonMini :to="`/patientrecords/${item.pid}`" class="h-8 justify-self-end"
-            >View Record</GenericButtonMini
-          >
+          <!-- Record links -->
+          <div v-click-away="closeMenu" class="justify-self-end flex items-center">
+            <GenericButtonMini :to="`/patientrecords/${item.pid}`" class="h-8">View Record</GenericButtonMini>
+            <GenericButtonMini class="h-8 ml-1" @click="showMenu = !showMenu"><IconChevronDown /></GenericButtonMini>
+          </div>
+          <GenericMenu class="mt-8" :show="showMenu">
+            <GenericMenuItem @click.native="copyPID"> Copy PID </GenericMenuItem>
+            <GenericMenuItem :disabled="true"> Delete Record </GenericMenuItem>
+          </GenericMenu>
         </div>
       </div>
     </div>
@@ -46,7 +51,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from '@nuxtjs/composition-api'
+import { defineComponent, ref, useContext } from '@nuxtjs/composition-api'
 import { formatDate } from '@/utilities/dateUtils'
 import { PatientRecord } from '@/interfaces/patientrecord'
 
@@ -57,9 +62,30 @@ export default defineComponent({
       required: true,
     },
   },
-  setup() {
+  setup(props) {
+    const { $toast } = useContext()
+
     const showDetail = ref(false)
-    return { showDetail, formatDate }
+    const showMenu = ref(false)
+
+    function closeMenu() {
+      showMenu.value = false
+    }
+
+    function copyPID() {
+      navigator.clipboard.writeText(props.item.pid).then(() => {
+        closeMenu()
+        $toast.show({
+          type: 'success',
+          title: 'Success',
+          message: 'PID copied to clipboard',
+          timeout: 5,
+          classTimeout: 'bg-green-600',
+        })
+      })
+    }
+
+    return { showDetail, showMenu, closeMenu, copyPID, formatDate }
   },
 })
 </script>

--- a/components/patientrecords/ManageMenu.vue
+++ b/components/patientrecords/ManageMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <PatientrecordsDeleteModal ref="deleteModal" :item="item" />
+    <PatientrecordsDeleteModal ref="deleteModal" :item="item" @deleted="$emit('deleted')" />
     <div v-click-away="closeMenu" class="justify-self-end flex items-center">
       <GenericButtonMini label="Manage record" tooltip="Manage Record" class="h-8 ml-1" @click="showMenu = !showMenu">
         <IconChevronDown />

--- a/components/patientrecords/ManageMenu.vue
+++ b/components/patientrecords/ManageMenu.vue
@@ -7,7 +7,9 @@
       </GenericButtonMini>
       <GenericMenu class="mt-8" :show="showMenu">
         <GenericMenuItem @click.native="copyPID"> Copy PID </GenericMenuItem>
-        <GenericMenuItem @click.native="showDeleteModal"> Delete Record </GenericMenuItem>
+        <GenericMenuItem v-if="hasPermission('ukrdc:records:delete')" @click.native="showDeleteModal">
+          Delete Record
+        </GenericMenuItem>
       </GenericMenu>
     </div>
   </div>
@@ -17,6 +19,7 @@
 import { defineComponent, ref, useContext } from '@nuxtjs/composition-api'
 import { PatientRecord } from '@/interfaces/patientrecord'
 import { modalInterface } from '~/interfaces/modal'
+import usePermissions from '~/mixins/usePermissions'
 
 export default defineComponent({
   props: {
@@ -27,6 +30,7 @@ export default defineComponent({
   },
   setup(props) {
     const { $toast } = useContext()
+    const { hasPermission } = usePermissions()
 
     const deleteModal = ref<modalInterface>()
 
@@ -54,7 +58,7 @@ export default defineComponent({
       deleteModal.value?.show()
     }
 
-    return { deleteModal, showMenu, closeMenu, copyPID, showDeleteModal }
+    return { deleteModal, showMenu, closeMenu, copyPID, showDeleteModal, hasPermission }
   },
 })
 </script>

--- a/components/patientrecords/ManageMenu.vue
+++ b/components/patientrecords/ManageMenu.vue
@@ -10,6 +10,12 @@
         <GenericMenuItem v-if="hasPermission('ukrdc:records:delete')" @click.native="showDeleteModal">
           Delete Record
         </GenericMenuItem>
+        <GenericMenuItem
+          v-if="hasPermission('ukrdc:records:write') && hasPermission('ukrdc:empi:write')"
+          :disabled="true"
+        >
+          Unlink Record
+        </GenericMenuItem>
       </GenericMenu>
     </div>
   </div>

--- a/components/patientrecords/ManageMenu.vue
+++ b/components/patientrecords/ManageMenu.vue
@@ -1,0 +1,60 @@
+<template>
+  <div>
+    <PatientrecordsDeleteModal ref="deleteModal" :item="item" />
+    <div v-click-away="closeMenu" class="justify-self-end flex items-center">
+      <GenericButtonMini label="Manage record" tooltip="Manage Record" class="h-8 ml-1" @click="showMenu = !showMenu">
+        <IconChevronDown />
+      </GenericButtonMini>
+      <GenericMenu class="mt-8" :show="showMenu">
+        <GenericMenuItem @click.native="copyPID"> Copy PID </GenericMenuItem>
+        <GenericMenuItem @click.native="showDeleteModal"> Delete Record </GenericMenuItem>
+      </GenericMenu>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, useContext } from '@nuxtjs/composition-api'
+import { PatientRecord } from '@/interfaces/patientrecord'
+import { modalInterface } from '~/interfaces/modal'
+
+export default defineComponent({
+  props: {
+    item: {
+      type: Object as () => PatientRecord,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { $toast } = useContext()
+
+    const deleteModal = ref<modalInterface>()
+
+    const showMenu = ref(false)
+
+    function closeMenu() {
+      showMenu.value = false
+    }
+
+    function copyPID() {
+      navigator.clipboard.writeText(props.item.pid).then(() => {
+        closeMenu()
+        $toast.show({
+          type: 'success',
+          title: 'Success',
+          message: 'PID copied to clipboard',
+          timeout: 5,
+          classTimeout: 'bg-green-600',
+        })
+      })
+    }
+
+    function showDeleteModal() {
+      closeMenu()
+      deleteModal.value?.show()
+    }
+
+    return { deleteModal, showMenu, closeMenu, copyPID, showDeleteModal }
+  },
+})
+</script>

--- a/components/transition/Modal.vue
+++ b/components/transition/Modal.vue
@@ -1,0 +1,12 @@
+<template>
+  <transition
+    enter-active-class="ease-out"
+    enter-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    enter-to-class="opacity-100 translate-y-0 sm:scale-100"
+    leave-active-class="ease-in"
+    leave-class="opacity-100 translate-y-0 sm:scale-100"
+    leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+  >
+    <slot></slot>
+  </transition>
+</template>

--- a/interfaces/linkrecords.ts
+++ b/interfaces/linkrecords.ts
@@ -6,3 +6,9 @@ export interface LinkRecord {
   person: Person
   masterRecord: MasterRecord
 }
+
+export interface LinkRecordSummary {
+  id: number
+  personId: number
+  masterId: number
+}

--- a/interfaces/patientrecord.ts
+++ b/interfaces/patientrecord.ts
@@ -1,4 +1,7 @@
 import { Patient } from '@/interfaces/patient'
+import { Medication } from './medication'
+import { Observation } from './observation'
+import { Survey } from './survey'
 
 interface ProgramMembership {
   programName: string
@@ -32,4 +35,83 @@ export interface PatientRecord {
   patient: Patient
 
   links: PatientRecordLinks
+}
+
+interface idPidInterface {
+  id: string
+  pid: string
+}
+
+interface Diagnosis {
+  id: string
+  pid: string
+
+  diagnosisCode: string
+  diagnosisCodeStd: string
+  diagnosisDesc: string
+
+  identificationTime: string
+  onsetTime: string
+
+  comments: string
+}
+
+interface RenalDiagnosis {
+  pid: string
+
+  diagnosisCode: string
+  diagnosisCodeStd: string
+  diagnosisDesc: string
+
+  identificationTime: string
+
+  comments: string
+}
+
+interface Document {
+  id: string
+  pid: string
+
+  idx: string
+  documenttime: string
+  notetext: string
+
+  documenttypecode: string
+  documenttypecodestd: string
+  documenttypedesc: string
+
+  filename: string
+  filetype: string
+}
+
+interface Encounter {
+  id: string
+  pid: string
+
+  fromTime: string
+  toTime: string
+}
+
+interface PVDelete {
+  did: number
+  pid: string
+  observationTime: string
+  serviceId: string
+}
+
+export interface PatientRecordFull extends PatientRecord {
+  socialHistories: idPidInterface[]
+  familyHistories: idPidInterface[]
+  observations: Observation[]
+  allergies: idPidInterface[]
+  diagnoses: Diagnosis[]
+  renaldiagnoses: RenalDiagnosis[]
+  medications: Medication[]
+  procedures: idPidInterface[]
+  documents: Document[]
+  encounters: Encounter[]
+  programMemberships: ProgramMembership[]
+  clinicalRelationships: idPidInterface[]
+  surveys: Survey[]
+  pvdelete: PVDelete[]
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,6 +27,7 @@ export default {
     { ssr: false, src: '~/plugins/toast.ts' },
     { ssr: false, src: '~/plugins/axios-toast.ts' },
     { ssr: true, src: '~/plugins/axios-sentry.ts' },
+    { ssr: false, src: '~/plugins/vue-clickaway.ts' },
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/pages/masterrecords/_id/index.vue
+++ b/pages/masterrecords/_id/index.vue
@@ -75,7 +75,7 @@
       <ul v-if="$fetchState.pending" class="divide-y divide-gray-200">
         <SkeleListItem v-for="n in 5" :key="n" />
       </ul>
-      <PatientrecordsGroupedList v-else :records="patientRecords" />
+      <PatientrecordsGroupedList v-else :records="patientRecords" @refresh="refreshRecords" />
     </GenericCard>
 
     <!-- Related Master Records card -->
@@ -180,7 +180,7 @@ export default defineComponent({
       )}`
     })
 
-    useFetch(async () => {
+    const { fetch } = useFetch(async () => {
       // Use the record links to load related data concurrently
       const [latestMessageResponse, relatedRecordsResponse, patientRecordsResponse] = await Promise.all([
         $axios.$get(props.record.links.latestMessage),
@@ -196,12 +196,18 @@ export default defineComponent({
       patientRecords.value = patientRecordsResponse
     })
 
+    function refreshRecords() {
+      console.log('Refreshing Patient Records...')
+      fetch()
+    }
+
     return {
       patientRecords,
       relatedRecords,
       tracingRecord,
       latestMessage,
       latestMessageInfo,
+      refreshRecords,
       formatGender,
       formatDate,
       nameMatchesTracing,

--- a/plugins/vue-clickaway.ts
+++ b/plugins/vue-clickaway.ts
@@ -1,0 +1,82 @@
+/*
+Based on VinceG/vue-click-away
+
+MIT License
+
+Copyright (c) 2020 Vincent Gabriel <vadimg88@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import Vue, { VNode } from 'vue'
+import { DirectiveBinding } from 'vue/types/options'
+
+const clickEventType = document.ontouchstart !== null ? 'click' : 'touchstart'
+
+interface ClickAwayElement extends HTMLElement {
+  // eslint-disable-next-line camelcase
+  __vue_click_away__?: (event: Event) => void
+}
+
+const onMounted = (el: ClickAwayElement, binding: DirectiveBinding, vnode: VNode) => {
+  // Remove any existing clickaway callbacks
+  onUnmounted(el)
+
+  const vm = vnode.context
+  const callback = binding.value
+
+  let nextTick = false
+  setTimeout(function () {
+    nextTick = true
+  }, 0)
+
+  el.__vue_click_away__ = (event: Event) => {
+    if ((!el || !el.contains(event.target as Node)) && callback && nextTick && typeof callback === 'function') {
+      return callback.call(vm, event)
+    }
+  }
+
+  document.addEventListener(clickEventType, el.__vue_click_away__, false)
+}
+
+const onUnmounted = (el: ClickAwayElement) => {
+  if (el.__vue_click_away__) {
+    document.removeEventListener(clickEventType, el.__vue_click_away__, false)
+    delete el.__vue_click_away__
+  }
+}
+
+const onUpdated = (el: ClickAwayElement, binding: DirectiveBinding, vnode: VNode) => {
+  if (binding.value === binding.oldValue) {
+    return
+  }
+  onMounted(el, binding, vnode)
+}
+
+const directive = {
+  inserted: onMounted,
+  componentUpdated: onUpdated,
+  unbind: onUnmounted,
+  // Vue 3:
+  // mounted: onMounted,
+  // updated: onUpdated,
+  // unmounted: onUnmounted,
+}
+
+Vue.directive('click-away', directive)


### PR DESCRIPTION
Will eventually be used as an interface for https://github.com/renalreg/ukrdc-fastapi/pull/144

# Todo

- [x] Accessibility label for chevron button
- [x] Tooltip for chevron button
- [x] Enable delete record functionality
  - [x] Create confirmation modal
  - [x] Fetch preview in confirmation modal
    - [x] Disable buttons while preview is loading
  - [x] Nicely render preview in modal
  - [x] Send confirmed delete request
  - [x] Emit event to refresh parent
  - [x] Re-fetch Master Record after delete
  - [x] Remove delete from menu if user lacks sufficient permissions