### PR TITLE
WorkItem UI improvements

### DIFF
--- a/components/generic/Dl.vue
+++ b/components/generic/Dl.vue
@@ -1,7 +1,22 @@
 <!-- Description list container component, formatted as a responsive grid -->
 
 <template>
-  <dl class="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2 lg:grid-cols-3">
+  <dl class="grid grid-cols-1 gap-4" :class="[{ 'lg:grid-cols-3': cols >= 3 }, { 'sm:grid-cols-2': cols >= 2 }]">
     <slot></slot>
   </dl>
 </template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  props: {
+    cols: {
+      type: Number,
+      required: false,
+      default: 3,
+    },
+  },
+  setup() {},
+})
+</script>

--- a/components/generic/TabToggle.vue
+++ b/components/generic/TabToggle.vue
@@ -6,7 +6,7 @@
     >
       <!-- Current: "text-gray-900", Default: "text-gray-500 hover:text-gray-700" -->
       <button
-        class="rounded-md focus:outline-none focus:ring-offset-gray-100"
+        class="rounded-md focus:outline-none focus:ring-offset-gray-100 truncate"
         :class="
           !value
             ? 'p-1.5 rounded-md bg-white shadow-sm focus:shadow-md ring-1 ring-black ring-opacity-5'
@@ -18,7 +18,7 @@
       </button>
 
       <button
-        class="rounded-md focus:outline-none focus:ring-offset-gray-100"
+        class="rounded-md focus:outline-none focus:ring-offset-gray-100 truncate"
         :class="
           value
             ? 'p-1.5 rounded-md bg-white shadow-sm focus:shadow-md ring-1 ring-black ring-opacity-5'

--- a/components/generic/TabToggle.vue
+++ b/components/generic/TabToggle.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <nav
+      class="grid grid-cols-2 group p-0.5 rounded-lg bg-gray-100 hover:bg-gray-200 text-sm font-medium"
+      aria-label="Tabs"
+    >
+      <!-- Current: "text-gray-900", Default: "text-gray-500 hover:text-gray-700" -->
+      <button
+        class="focus:ring-2 focus:ring-indigo-500 rounded-md focus:outline-none focus:ring-offset-gray-100"
+        @click="$emit('input', false)"
+      >
+        <div :class="!value ? 'p-1.5 rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5' : ''">
+          {{ falseLabel }}
+        </div>
+      </button>
+
+      <button
+        class="focus:ring-2 focus:ring-indigo-500 rounded-md focus:outline-none focus:ring-offset-gray-100"
+        @click="$emit('input', true)"
+      >
+        <div :class="value ? 'p-1.5 rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5' : ''">
+          {{ trueLabel }}
+        </div>
+      </button>
+    </nav>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  props: {
+    value: {
+      type: Boolean,
+      required: true,
+    },
+    trueLabel: {
+      type: String,
+      required: true,
+    },
+    falseLabel: {
+      type: String,
+      required: true,
+    },
+  },
+  setup() {
+    return {}
+  },
+})
+</script>

--- a/components/generic/TabToggle.vue
+++ b/components/generic/TabToggle.vue
@@ -6,21 +6,27 @@
     >
       <!-- Current: "text-gray-900", Default: "text-gray-500 hover:text-gray-700" -->
       <button
-        class="focus:ring-2 focus:ring-indigo-500 rounded-md focus:outline-none focus:ring-offset-gray-100"
+        class="rounded-md focus:outline-none focus:ring-offset-gray-100"
+        :class="
+          !value
+            ? 'p-1.5 rounded-md bg-white shadow-sm focus:shadow-md ring-1 ring-black ring-opacity-5'
+            : 'focus:bg-gray-200'
+        "
         @click="$emit('input', false)"
       >
-        <div :class="!value ? 'p-1.5 rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5' : ''">
-          {{ falseLabel }}
-        </div>
+        {{ falseLabel }}
       </button>
 
       <button
-        class="focus:ring-2 focus:ring-indigo-500 rounded-md focus:outline-none focus:ring-offset-gray-100"
+        class="rounded-md focus:outline-none focus:ring-offset-gray-100"
+        :class="
+          value
+            ? 'p-1.5 rounded-md bg-white shadow-sm focus:shadow-md ring-1 ring-black ring-opacity-5'
+            : 'focus:bg-gray-200'
+        "
         @click="$emit('input', true)"
       >
-        <div :class="value ? 'p-1.5 rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5' : ''">
-          {{ trueLabel }}
-        </div>
+        {{ trueLabel }}
       </button>
     </nav>
   </div>

--- a/components/generic/card/Dd.vue
+++ b/components/generic/card/Dd.vue
@@ -1,0 +1,5 @@
+<template>
+  <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">
+    <slot />
+  </dd>
+</template>

--- a/components/generic/card/Di.vue
+++ b/components/generic/card/Di.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 h-14">
+    <slot />
+  </div>
+</template>

--- a/components/generic/card/Dl.vue
+++ b/components/generic/card/Dl.vue
@@ -1,0 +1,5 @@
+<template>
+  <dl class="sm:divide-y sm:divide-gray-200">
+    <slot />
+  </dl>
+</template>

--- a/components/generic/card/Dt.vue
+++ b/components/generic/card/Dt.vue
@@ -1,0 +1,5 @@
+<template>
+  <dt class="font-medium text-gray-500">
+    <slot />
+  </dt>
+</template>

--- a/components/icon/SwitchH.vue
+++ b/components/icon/SwitchH.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="h-6 mx-auto my-2 text-gray-400"
+    class="h-6 mx-auto text-gray-400"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/components/icon/SwitchV.vue
+++ b/components/icon/SwitchV.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="h-6 mx-auto my-2 text-gray-400"
+    class="h-6 mx-auto text-gray-400"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/components/masterrecords/RecordCard.vue
+++ b/components/masterrecords/RecordCard.vue
@@ -1,6 +1,6 @@
 <template>
   <GenericCard>
-    <div class="px-4 py-5 sm:px-6">
+    <div class="px-4 sm:px-6 h-24 flex flex-col justify-center">
       <h3
         class="text-lg leading-6 font-medium text-gray-900 capitalize"
         :class="highlight.includes('name') ? highlightClasses : []"
@@ -8,48 +8,43 @@
         {{ record.givenname.toLowerCase() }}
         {{ record.surname.toLowerCase() }}
       </h3>
-      <p v-if="label" class="mt-1 max-w-2xl text-gray-500">
-        {{ label }}
+      <p class="mt-1 max-w-2xl text-gray-500">
+        {{ label ? label : `Master Record ${record.id}` }}
       </p>
     </div>
     <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
-      <dl class="sm:divide-y sm:divide-gray-200">
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">National ID</dt>
-          <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2 align-middle">
-            <p>
-              {{ record.nationalid }}
-            </p>
-            <p>
-              {{ record.nationalidType }}
-            </p>
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Date of Birth</dt>
-          <dd
-            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
-            :class="highlight.includes('dateOfBirth') ? highlightClasses : []"
-          >
+      <GenericCardDl>
+        <GenericCardDi>
+          <GenericCardDt>National ID</GenericCardDt>
+          <GenericCardDd>
+            {{ record.nationalid }}
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>ID Type</GenericCardDt>
+          <GenericCardDd class="align-middle">
+            {{ record.nationalidType }}
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Date of Birth</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('dateOfBirth') ? highlightClasses : []">
             {{ formatDate(record.dateOfBirth, (t = false)) }}
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Assigned Gender</dt>
-          <dd
-            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
-            :class="highlight.includes('gender') ? highlightClasses : []"
-          >
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Assigned Gender</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('gender') ? highlightClasses : []">
             {{ formatGender(record.gender) }}
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Last Updated</dt>
-          <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Last Updated</GenericCardDt>
+          <GenericCardDd>
             {{ formatDate(record.lastUpdated) }}
-          </dd>
-        </div>
-      </dl>
+          </GenericCardDd>
+        </GenericCardDi>
+      </GenericCardDl>
     </div>
   </GenericCard>
 </template>

--- a/components/patientrecords/survey/Viewer.vue
+++ b/components/patientrecords/survey/Viewer.vue
@@ -9,7 +9,7 @@
           </p>
         </div>
         <div class="border-t border-gray-200 px-4 py-5">
-          <dl class="sm:divide-y sm:divide-gray-200">
+          <GenericCardDl>
             <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4">
               <dt class="font-medium text-gray-500">Entered On</dt>
               <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">
@@ -34,7 +34,7 @@
                 {{ survey.surveytypecode }}
               </dd>
             </div>
-          </dl>
+          </GenericCardDl>
         </div>
       </div>
 
@@ -46,7 +46,7 @@
             </h3>
           </div>
           <div class="border-t border-gray-200 px-4">
-            <dl class="sm:divide-y sm:divide-gray-200">
+            <GenericCardDl>
               <div v-for="question in questions" :key="question.id" class="flex items-center py-4">
                 <div class="mr-4 font-medium text-gray-900">
                   {{ question.questiontypecode }}
@@ -60,7 +60,7 @@
                   </dd>
                 </div>
               </div>
-            </dl>
+            </GenericCardDl>
           </div>
         </div>
       </div>

--- a/components/persons/RecordCard.vue
+++ b/components/persons/RecordCard.vue
@@ -1,64 +1,61 @@
 <template>
   <GenericCard>
-    <div class="px-4 py-5 sm:px-6">
+    <div class="px-4 sm:px-6 h-24 flex flex-col justify-center">
       <h3 class="text-lg leading-6 font-medium text-gray-900 capitalize">
         {{ record.givenname.toLowerCase() }}
         {{ record.surname.toLowerCase() }}
       </h3>
-      <p v-if="label" class="mt-1 max-w-2xl text-gray-500">
-        {{ label }}
+      <p class="mt-1 max-w-2xl text-gray-500">
+        {{ label ? label : `Person Record ${record.id}` }}
       </p>
     </div>
     <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
-      <dl class="sm:divide-y sm:divide-gray-200">
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Local ID</dt>
-          <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2 align-middle">
-            <div :class="highlight.includes('localid') ? highlightClasses : []">
-              {{ realLocalID.localid }}
-            </div>
-            <div>
-              <span :class="highlight.includes('sendingFacility') ? highlightClasses : []">{{
-                `${realLocalID.sendingFacility ? realLocalID.sendingFacility : record.localidType}`
-              }}</span>
-              <span :class="highlight.includes('sendingExtract') ? highlightClasses : []">{{
-                `${realLocalID.sendingExtract ? 'via ' + realLocalID.sendingExtract : ''}`
-              }}</span>
-            </div>
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Date of Birth</dt>
+      <GenericCardDl>
+        <GenericCardDi>
+          <GenericCardDt>Local ID</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('localid') ? highlightClasses : []">
+            {{ realLocalID.localid }}
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Sender</GenericCardDt>
+          <GenericCardDd>
+            <span :class="highlight.includes('sendingFacility') ? highlightClasses : []">{{
+              `${realLocalID.sendingFacility ? realLocalID.sendingFacility : record.localidType}`
+            }}</span>
+            <span :class="highlight.includes('sendingExtract') ? highlightClasses : []">{{
+              `${realLocalID.sendingExtract ? 'via ' + realLocalID.sendingExtract : ''}`
+            }}</span>
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Date of Birth</GenericCardDt>
           <dd
             class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
             :class="highlight.includes('dateOfBirth') ? highlightClasses : []"
           >
             {{ formatDate(record.dateOfBirth, (t = false)) }}
           </dd>
-        </div>
-        <div v-if="record.dateOfDeath || full" class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Date of Death</dt>
-          <dd
-            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
-            :class="highlight.includes('dateOfDeath') ? highlightClasses : []"
-          >
-            {{ record.dateOfDeath ? formatDate(record.dateOfDeath, (t = false)) : 'N/A' }}
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Assigned Gender</dt>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Assigned Gender</GenericCardDt>
           <dd
             class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
             :class="highlight.includes('gender') ? highlightClasses : []"
           >
             {{ formatGender(record.gender) }}
           </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Last Updated</dt>
-          <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">N/A</dd>
-        </div>
-      </dl>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Date of Death</GenericCardDt>
+          <dd
+            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
+            :class="highlight.includes('dateOfDeath') ? highlightClasses : []"
+          >
+            {{ record.dateOfDeath ? formatDate(record.dateOfDeath, (t = false)) : 'N/A' }}
+          </dd>
+        </GenericCardDi>
+      </GenericCardDl>
     </div>
   </GenericCard>
 </template>
@@ -86,11 +83,6 @@ export default defineComponent({
       type: String,
       required: false,
       default: null,
-    },
-    full: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
     highlight: {
       type: Array,

--- a/components/persons/RecordCard.vue
+++ b/components/persons/RecordCard.vue
@@ -1,10 +1,15 @@
 <template>
   <GenericCard>
     <div class="px-4 sm:px-6 h-24 flex flex-col justify-center">
-      <h3 class="text-lg leading-6 font-medium text-gray-900 capitalize">
-        {{ record.givenname.toLowerCase() }}
-        {{ record.surname.toLowerCase() }}
-      </h3>
+      <span
+        :class="highlight.includes('givenname') || highlight.includes('surname') ? highlightClasses : ['text-gray-900']"
+      >
+        <h3 class="text-lg leading-6 font-medium capitalize">
+          {{ record.givenname.toLowerCase() }}
+          {{ record.surname.toLowerCase() }}
+        </h3>
+      </span>
+
       <p class="mt-1 max-w-2xl text-gray-500">
         {{ label ? label : `Person Record ${record.id}` }}
       </p>

--- a/components/workitems/AdviceCard.vue
+++ b/components/workitems/AdviceCard.vue
@@ -3,14 +3,48 @@
     <GenericCardHeader><TextH2>Advice</TextH2></GenericCardHeader>
     <GenericCardContent>
       <ul v-if="item">
-        <!--  Allow v-html since we know it will always be sourced from advicesMap -->
-        <!--  eslint-disable vue/no-v-html -->
-        <li
-          v-for="(adviceIndex, index) in workItemAdvices"
-          :key="`advice${index}`"
-          class="mb-2"
-          v-html="advicesMap[adviceIndex]"
-        ></li>
+        <li v-if="workItemAdvices.includes(2)">
+          <TextP>Related Work Items labelled UKRDC should be resolved first. See below.</TextP>
+        </li>
+        <li v-if="workItemAdvices.includes(4)">
+          <TextP
+            >You may need to use PatientView, RaDaR, or DemoGraphicGenerator.exe to issue a demographic update before
+            closing this Work Item.</TextP
+          >
+        </li>
+        <li v-if="workItemAdvices.includes(5)">
+          <TextP class="mb-1">
+            Check the <span class="text-indigo-600 font-bold">Proposed Merge</span> below, then click
+            <span class="text-yellow-600 font-bold">Merge Master Records</span> if the link is valid.
+          </TextP>
+          <TextP>
+            You may need to use PatientView, RaDaR, or DemoGraphicGenerator.exe to issue a demographic update before
+            merging records.
+          </TextP>
+        </li>
+        <li v-if="workItemAdvices.includes(6)">
+          <TextP>This Work Item was recently merged, and can now be closed.</TextP>
+        </li>
+        <li v-if="workItemAdvices.includes(7)">
+          <TextP
+            >A previous merge may have been completed but Person record data was not correctly updated to match.</TextP
+          >
+        </li>
+        <li v-if="workItemAdvices.includes(9)">
+          <TextP
+            >See
+            <a
+              href="https://confluence.ukrdc.org/display/TNG/Person+matched+by+facility%2C+extract+and+national+id+-+not+matched+by+demographics"
+              target="_blank"
+              >documentation on Confluence</a
+            >
+            for advice on resolving this work item.</TextP
+          >
+        </li>
+        <li v-if="workItemAdvices.includes(10)">
+          <TextP>This Work Item is already closed. No further action to be taken.</TextP>
+        </li>
+        <li v-if="workItemAdvices.includes(11)"><TextP>Related Work Items are still unresolved. See below.</TextP></li>
       </ul>
       <div v-else>
         <SkeleText class="h-6 mb-2 w-full" />
@@ -31,17 +65,6 @@ import {
   workItemIsSecondary,
   workItemIsUKRDC,
 } from '@/utilities/workItemUtils'
-
-const advicesMap = {
-  2: 'Related Work Items labelled UKRDC should be resolved first. See below.',
-  4: 'You may need to use PatientView, RaDaR, or DemoGraphicGenerator.exe to issue a demographic update before closing this Work Item.',
-  5: '<p>Check the proposed merge, then click Merge Master Records if the link is valid.</p> <p>You may need to use PatientView, RaDaR, or DemoGraphicGenerator.exe to issue a demographic update before merging records.</p>',
-  6: 'This Work Item was recently merged, and can now be closed.',
-  7: 'A previous merge may have been completed but Person record data was not correctly updated to match.',
-  9: 'See <a href="https://confluence.ukrdc.org/display/TNG/Person+matched+by+facility%2C+extract+and+national+id+-+not+matched+by+demographics" target="_blank">documentation on Confluence</a> for advice on resolving this work item',
-  10: 'This Work Item is already closed. No further action to be taken.',
-  11: 'Related Work Items are still unresolved. See below.',
-}
 
 export default defineComponent({
   props: {
@@ -106,7 +129,7 @@ export default defineComponent({
 
       return advices
     })
-    return { workItemAdvices, advicesMap }
+    return { workItemAdvices }
   },
 })
 </script>

--- a/components/workitems/AdviceCard.vue
+++ b/components/workitems/AdviceCard.vue
@@ -3,9 +3,14 @@
     <GenericCardHeader><TextH2>Advice</TextH2></GenericCardHeader>
     <GenericCardContent>
       <ul v-if="item">
-        <li v-for="(adviceIndex, index) in workItemAdvices" :key="`advice${index}`" class="mb-2">
-          {{ advicesMap[adviceIndex] }}
-        </li>
+        <!--  Allow v-html since we know it will always be sourced from advicesMap -->
+        <!--  eslint-disable vue/no-v-html -->
+        <li
+          v-for="(adviceIndex, index) in workItemAdvices"
+          :key="`advice${index}`"
+          class="mb-2"
+          v-html="advicesMap[adviceIndex]"
+        ></li>
       </ul>
       <div v-else>
         <SkeleText class="h-6 mb-2 w-full" />
@@ -21,6 +26,16 @@ import { computed, defineComponent } from '@nuxtjs/composition-api'
 import { WorkItemExtended } from '@/interfaces/workitem'
 import { workItemIsMergable } from '@/utilities/workItemUtils'
 
+const advicesMap = {
+  0: 'No advice available.',
+  1: 'This Work Item is already closed.',
+  2: 'Related Work Items labelled UKRDC should be resolved first. See below.',
+  3: 'No new incoming Master Records. This Work Item can probably be closed.',
+  4: 'You may need to use DemoGraphicGenerator.exe to issue a demographic update before closing this Work Item.',
+  5: 'Check the proposed merge, then click Merge Master Records if the link is valid.',
+  9: 'See <a href="https://confluence.ukrdc.org/display/TNG/Person+matched+by+facility%2C+extract+and+national+id+-+not+matched+by+demographics" target="_blank">documentation on Confluence</a> for advice on resolving this work item',
+}
+
 export default defineComponent({
   props: {
     item: {
@@ -35,15 +50,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const advicesMap = {
-      0: 'No advice available.',
-      1: 'This Work Item is already closed.',
-      2: 'Related Work Items labelled UKRDC should be resolved first. See below.',
-      3: 'No new incoming Master Records. This Work Item can probably be closed.',
-      4: 'You may need to use DemoGraphicGenerator.exe to issue a demographic update before closing this Work Item.',
-      5: 'Check incoming and destination records, then merge the two records if the link is valid.',
-    }
-
     const workItemAdvices = computed(() => {
       const advices: number[] = []
       // If we have a Work Item record
@@ -52,44 +58,49 @@ export default defineComponent({
         if (props.item.status === 3) {
           // Advise that the Work Item is already closed
           advices.push(1)
-        }
-        // If the Work Item is part of a collection
-        if (props.related.length > 0) {
-          // For each related Work Item in the collection
-          for (const relatedItem of props.related) {
-            // If the related Work Item is a mergable UKRDC Work Item
-            if (relatedItem.masterRecord.nationalidType === 'UKRDC' && relatedItem.status !== 3) {
-              // Advise that the UKRDC item should be resolved first
-              advices.push(2)
-              break
+        } else {
+          // If the Work Item is part of a collection
+          if (props.related.length > 0) {
+            // For each related Work Item in the collection
+            for (const relatedItem of props.related) {
+              // If the related Work Item is a mergable UKRDC Work Item
+              if (relatedItem.masterRecord.nationalidType === 'UKRDC' && relatedItem.status !== 3) {
+                // Advise that the UKRDC item should be resolved first
+                advices.push(2)
+                break
+              }
             }
           }
-        }
-        // For type 6 or 7 work items
-        if (props.item.type === 6 || props.item.type === 7) {
-          // If there are no incoming Master Records
-          if (props.item.incoming.masterRecords.length === 0) {
-            if (props.item.status !== 3) {
-              // Advise that the workitem is probably ready to be closed
-              advices.push(3)
-            }
-          } else {
-            // Advise that a demographic update may be required
-            advices.push(4)
+          // For type 9 work items
+          if (props.item.type === 9) {
+            advices.push(9)
           }
-        }
-        // For type 3 or 4 work items
-        else if (props.item.type === 3 || props.item.type === 4) {
-          // If there are no incoming Master Records
-          if (props.item.incoming.masterRecords.length === 0) {
-            if (props.item.status !== 3) {
-              // Advise that the workitem is probably ready to be closed
-              advices.push(3)
+          // For type 6 or 7 work items
+          if (props.item.type === 6 || props.item.type === 7) {
+            // If there are no incoming Master Records
+            if (props.item.incoming.masterRecords.length === 0) {
+              if (props.item.status !== 3) {
+                // Advise that the workitem is probably ready to be closed
+                advices.push(3)
+              }
+            } else {
+              // Advise that a demographic update may be required
+              advices.push(4)
             }
-            // If records are mergable (i.e. both are UKRDC records)
-          } else if (workItemIsMergable(props.item)) {
-            // Advise that records could be merged
-            advices.push(5)
+          }
+          // For type 3 or 4 work items
+          else if (props.item.type === 3 || props.item.type === 4) {
+            // If there are no incoming Master Records
+            if (props.item.incoming.masterRecords.length === 0) {
+              if (props.item.status !== 3) {
+                // Advise that the workitem is probably ready to be closed
+                advices.push(3)
+              }
+              // If records are mergable (i.e. both are UKRDC records)
+            } else if (workItemIsMergable(props.item)) {
+              // Advise that records could be merged
+              advices.push(5)
+            }
           }
         }
       }
@@ -105,3 +116,9 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="postcss">
+a {
+  @apply text-indigo-600;
+}
+</style>

--- a/components/workitems/AdviceCard.vue
+++ b/components/workitems/AdviceCard.vue
@@ -1,0 +1,107 @@
+<template>
+  <GenericCard>
+    <GenericCardHeader><TextH2>Advice</TextH2></GenericCardHeader>
+    <GenericCardContent>
+      <ul v-if="item">
+        <li v-for="(adviceIndex, index) in workItemAdvices" :key="`advice${index}`" class="mb-2">
+          {{ advicesMap[adviceIndex] }}
+        </li>
+      </ul>
+      <div v-else>
+        <SkeleText class="h-6 mb-2 w-full" />
+        <SkeleText class="h-6 mb-2 w-1/2" />
+        <SkeleText class="h-6 mb-2 w-3/4" />
+      </div>
+    </GenericCardContent>
+  </GenericCard>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { WorkItemExtended } from '@/interfaces/workitem'
+import { workItemIsMergable } from '@/utilities/workItemUtils'
+
+export default defineComponent({
+  props: {
+    item: {
+      type: Object as () => WorkItemExtended,
+      required: false,
+      default: undefined,
+    },
+    related: {
+      type: Array as () => WorkItemExtended[],
+      required: false,
+      default: () => [],
+    },
+  },
+  setup(props) {
+    const advicesMap = {
+      0: 'No advice available.',
+      1: 'This Work Item is already closed.',
+      2: 'Related Work Items labelled UKRDC should be resolved first. See below.',
+      3: 'No new incoming Master Records. This Work Item can probably be closed.',
+      4: 'You may need to use DemoGraphicGenerator.exe to issue a demographic update before closing this Work Item.',
+      5: 'Check incoming and destination records, then merge the two records if the link is valid.',
+    }
+
+    const workItemAdvices = computed(() => {
+      const advices: number[] = []
+      // If we have a Work Item record
+      if (props.item) {
+        // If the Work Item is already closed
+        if (props.item.status === 3) {
+          // Advise that the Work Item is already closed
+          advices.push(1)
+        }
+        // If the Work Item is part of a collection
+        if (props.related.length > 0) {
+          // For each related Work Item in the collection
+          for (const relatedItem of props.related) {
+            // If the related Work Item is a mergable UKRDC Work Item
+            if (relatedItem.masterRecord.nationalidType === 'UKRDC' && relatedItem.status !== 3) {
+              // Advise that the UKRDC item should be resolved first
+              advices.push(2)
+              break
+            }
+          }
+        }
+        // For type 6 or 7 work items
+        if (props.item.type === 6 || props.item.type === 7) {
+          // If there are no incoming Master Records
+          if (props.item.incoming.masterRecords.length === 0) {
+            if (props.item.status !== 3) {
+              // Advise that the workitem is probably ready to be closed
+              advices.push(3)
+            }
+          } else {
+            // Advise that a demographic update may be required
+            advices.push(4)
+          }
+        }
+        // For type 3 or 4 work items
+        else if (props.item.type === 3 || props.item.type === 4) {
+          // If there are no incoming Master Records
+          if (props.item.incoming.masterRecords.length === 0) {
+            if (props.item.status !== 3) {
+              // Advise that the workitem is probably ready to be closed
+              advices.push(3)
+            }
+            // If records are mergable (i.e. both are UKRDC records)
+          } else if (workItemIsMergable(props.item)) {
+            // Advise that records could be merged
+            advices.push(5)
+          }
+        }
+      }
+
+      // Advise if there is no advice available...
+      if (advices.length === 0) {
+        advices.push(0)
+      }
+
+      return advices
+    })
+    return { workItemAdvices, advicesMap }
+  },
+})
+</script>

--- a/components/workitems/AdviceCard.vue
+++ b/components/workitems/AdviceCard.vue
@@ -7,10 +7,10 @@
           <TextP>Related Work Items labelled UKRDC should be resolved first. See below.</TextP>
         </li>
         <li v-if="workItemAdvices.includes(4)">
-          <TextP
-            >You may need to use PatientView, RaDaR, or DemoGraphicGenerator.exe to issue a demographic update before
-            closing this Work Item.</TextP
-          >
+          <TextP>
+            You may need to use PatientView, RaDaR, or DemoGraphicGenerator.exe to issue a demographic update before
+            closing this Work Item.
+          </TextP>
         </li>
         <li v-if="workItemAdvices.includes(5)">
           <TextP class="mb-1">
@@ -26,20 +26,21 @@
           <TextP>This Work Item was recently merged, and can now be closed.</TextP>
         </li>
         <li v-if="workItemAdvices.includes(7)">
-          <TextP
-            >A previous merge may have been completed but Person record data was not correctly updated to match.</TextP
-          >
+          <TextP>
+            A previous merge may have been completed but Person record data was not correctly updated to match.
+          </TextP>
         </li>
         <li v-if="workItemAdvices.includes(9)">
-          <TextP
-            >See
+          <TextP>
+            See
             <a
               href="https://confluence.ukrdc.org/display/TNG/Person+matched+by+facility%2C+extract+and+national+id+-+not+matched+by+demographics"
               target="_blank"
-              >documentation on Confluence</a
             >
-            for advice on resolving this work item.</TextP
-          >
+              documentation on Confluence
+            </a>
+            for advice on resolving this work item.
+          </TextP>
         </li>
         <li v-if="workItemAdvices.includes(10)">
           <TextP>This Work Item is already closed. No further action to be taken.</TextP>

--- a/components/workitems/AttributeRecordCard.vue
+++ b/components/workitems/AttributeRecordCard.vue
@@ -1,68 +1,51 @@
 <template>
   <GenericCard>
-    <div class="px-4 py-5 sm:px-6">
-      <h3 class="text-lg leading-6 font-medium text-gray-900">
-        {{ record.givenname ? record.givenname : '' }}
-        {{ record.surname ? record.surname : '' }}
-      </h3>
-      <p v-if="label" class="mt-1 max-w-2xl text-gray-500">
-        {{ label }}
-      </p>
+    <div class="px-4 sm:px-6 h-24 flex flex-col justify-center">
+      <div class="text-gray-500" :class="highlight.includes('givenname') ? highlightClasses : []">
+        {{ record.givenname ? formatAttributeValue(record.givenname) : 'Given Name not specified' }}
+      </div>
+      <div class="text-gray-500 mt-1" :class="highlight.includes('surname') ? highlightClasses : []">
+        {{ record.surname ? formatAttributeValue(record.surname) : 'Surname not specified' }}
+      </div>
     </div>
     <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
-      <dl class="sm:divide-y sm:divide-gray-200">
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Local ID</dt>
-          <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2 align-middle">
-            <div v-if="record.localid" :class="highlight.includes('localid') ? highlightClasses : []">
-              {{ record.localid }}
-            </div>
-            <div>
-              <span
-                v-if="record.sendingFacility"
-                :class="highlight.includes('sendingFacility') ? highlightClasses : []"
-                >{{ record.sendingFacility }}</span
-              >
-              <span
-                v-if="record.sendingExtract"
-                :class="highlight.includes('sendingExtract') ? highlightClasses : []"
-                >{{ 'via ' + record.sendingExtract }}</span
-              >
-            </div>
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Date of Birth</dt>
-          <dd
-            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
-            :class="highlight.includes('dateOfBirth') ? highlightClasses : []"
-          >
+      <GenericCardDl>
+        <GenericCardDi>
+          <GenericCardDt>Local ID</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('localid') ? highlightClasses : []">
+            {{ record.localid ? formatAttributeValue(record.localid) : 'Not specified' }}
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Sender</GenericCardDt>
+          <GenericCardDd>
+            <span :class="highlight.includes('sendingFacility') ? highlightClasses : []">{{
+              record.sendingFacility ? record.sendingFacility : ''
+            }}</span>
+            <span :class="highlight.includes('sendingExtract') ? highlightClasses : []">{{
+              record.sendingExtract ? 'via ' + record.sendingExtract : 'Not specified'
+            }}</span>
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Date of Birth</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('dateOfBirth') ? highlightClasses : []">
             {{ formattedDoB }}
-          </dd>
-        </div>
-        <div v-if="record.dateOfDeath || full" class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Date of Death</dt>
-          <dd
-            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
-            :class="highlight.includes('dateOfDeath') ? highlightClasses : []"
-          >
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Assigned Gender</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('gender') ? highlightClasses : []">
+            {{ formattedGender }}
+          </GenericCardDd>
+        </GenericCardDi>
+        <GenericCardDi>
+          <GenericCardDt>Date of Death</GenericCardDt>
+          <GenericCardDd :class="highlight.includes('dateOfDeath') ? highlightClasses : []">
             {{ formattedDoD }}
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Assigned Gender</dt>
-          <dd
-            class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2"
-            :class="highlight.includes('gender') ? highlightClasses : []"
-          >
-            {{ formatGender(record.gender) }}
-          </dd>
-        </div>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="font-medium text-gray-500">Last Updated</dt>
-          <dd class="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">N/A</dd>
-        </div>
-      </dl>
+          </GenericCardDd>
+        </GenericCardDi>
+      </GenericCardDl>
     </div>
   </GenericCard>
 </template>
@@ -72,24 +55,20 @@ import { computed, defineComponent } from '@nuxtjs/composition-api'
 
 import { formatDate } from '@/utilities/dateUtils'
 import { formatGender } from '@/utilities/codeUtils'
+import { formatAttributeValue } from '@/utilities/workItemUtils'
 
-import { Person } from '~/interfaces/persons'
+import { WorkItemAttributes } from '~/interfaces/workitem'
 
 export default defineComponent({
   props: {
     record: {
-      type: Object as () => Person,
+      type: Object as () => WorkItemAttributes,
       required: true,
     },
     label: {
       type: String,
       required: false,
       default: null,
-    },
-    full: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
     highlight: {
       type: Array,
@@ -112,20 +91,36 @@ export default defineComponent({
     const formattedDoB = computed(() => {
       return props.record.dateOfBirth
         ? `
-        ${formatDate(props.record.dateOfBirth.split(':')[0], false)} : 
+        ${formatDate(props.record.dateOfBirth.split(':')[0], false)} → 
         ${formatDate(props.record.dateOfBirth.split(':')[1], false)}`
-        : 'N/A'
+        : 'Not specified'
     })
 
     const formattedDoD = computed(() => {
       return props.record.dateOfDeath
         ? `
-        ${formatDate(props.record.dateOfDeath.split(':')[0], false)} : 
+        ${formatDate(props.record.dateOfDeath.split(':')[0], false)} →
         ${formatDate(props.record.dateOfDeath.split(':')[1], false)}`
-        : 'N/A'
+        : 'Not specified'
     })
 
-    return { formattedDoB, formattedDoD, formatDate, formatGender, highlightClasses }
+    const formattedGender = computed(() => {
+      return props.record.gender
+        ? `
+        ${formatGender(props.record.gender.split(':')[0])} →
+        ${formatGender(props.record.gender.split(':')[1])}`
+        : 'Not specified'
+    })
+
+    return {
+      formattedDoB,
+      formattedDoD,
+      formattedGender,
+      formatDate,
+      formatGender,
+      formatAttributeValue,
+      highlightClasses,
+    }
   },
 })
 </script>

--- a/components/workitems/DetailCard.vue
+++ b/components/workitems/DetailCard.vue
@@ -1,0 +1,51 @@
+<template>
+  <GenericCard>
+    <GenericCardHeader><TextH2>Details</TextH2></GenericCardHeader>
+    <GenericCardContent>
+      <GenericDl>
+        <GenericDi>
+          <TextDt>Last Updated</TextDt>
+          <TextDd v-if="item">
+            {{ item.lastUpdated ? formatDate(item.lastUpdated) : 'Never' }}
+          </TextDd>
+          <SkeleText v-else class="h-6 w-full" />
+        </GenericDi>
+        <GenericDi>
+          <TextDt>Last Updated By</TextDt>
+          <TextDd v-if="item">
+            {{ item.updatedBy ? item.updatedBy : 'N/A' }}
+          </TextDd>
+          <SkeleText v-else class="h-6 w-full" />
+        </GenericDi>
+        <GenericDi class="sm:col-span-2">
+          <TextDt>Comments</TextDt>
+          <TextDd v-if="item">
+            {{ item.updateDescription ? item.updateDescription : 'None' }}
+          </TextDd>
+          <SkeleText v-else class="h-6 w-full" />
+        </GenericDi>
+      </GenericDl>
+    </GenericCardContent>
+  </GenericCard>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+import { formatDate } from '@/utilities/dateUtils'
+
+import { WorkItemExtended } from '@/interfaces/workitem'
+
+export default defineComponent({
+  props: {
+    item: {
+      type: Object as () => WorkItemExtended,
+      required: false,
+      default: undefined,
+    },
+  },
+  setup() {
+    return { formatDate }
+  },
+})
+</script>

--- a/components/workitems/DetailCard.vue
+++ b/components/workitems/DetailCard.vue
@@ -2,7 +2,7 @@
   <GenericCard>
     <GenericCardHeader><TextH2>Details</TextH2></GenericCardHeader>
     <GenericCardContent>
-      <GenericDl>
+      <GenericDl :cols="2">
         <GenericDi>
           <TextDt>Last Updated</TextDt>
           <TextDd v-if="item">

--- a/components/workitems/ListItem.vue
+++ b/components/workitems/ListItem.vue
@@ -46,9 +46,9 @@
       </div>
       <!-- Last updated (small and up) -->
       <div class="hidden lg:block">
-        <TextP>From {{ facility }}</TextP>
+        <TextP>{{ facility }} via {{ extract }}</TextP>
         <TextP class="mt-2">
-          {{ formatDate(item.lastUpdated) }}
+          {{ formatDate(item.creationDate) }}
         </TextP>
       </div>
     </div>
@@ -75,7 +75,14 @@ export default defineComponent({
         return 'Unknown Facility'
       }
     })
-    return { formatDate, facility }
+    const extract = computed(() => {
+      if (props.item.person?.xrefEntries[0]?.sendingExtract) {
+        return props.item.person?.xrefEntries[0]?.sendingExtract
+      } else {
+        return 'Unknown Extract'
+      }
+    })
+    return { formatDate, facility, extract }
   },
 })
 </script>

--- a/interfaces/workitem.ts
+++ b/interfaces/workitem.ts
@@ -11,6 +11,17 @@ interface WorkItemLinks {
   unlink: string
 }
 
+export interface WorkItemAttributes {
+  sendingExtract: string
+  sendingFacility: string
+  localid: string
+  dateOfBirth: string
+  dateOfDeath: string
+  gender: string
+  givenname: string
+  surname: string
+}
+
 export interface WorkItem {
   id: number
 
@@ -24,7 +35,7 @@ export interface WorkItem {
   updatedBy: string
   updateDescription: string
 
-  attributes: object
+  attributes: WorkItemAttributes
 
   masterRecord: MasterRecord
   person: Person

--- a/interfaces/workitem.ts
+++ b/interfaces/workitem.ts
@@ -3,6 +3,7 @@ import { MasterRecord } from '@/interfaces/masterrecord'
 
 interface WorkItemLinks {
   self: string
+  collection: string
   related: string
   errors: string
   merge: string
@@ -16,10 +17,13 @@ export interface WorkItem {
   type: number
   description: string
   status: number
+
+  creationDate: string
+
   lastUpdated: string
   updatedBy: string
-
   updateDescription: string
+
   attributes: object
 
   masterRecord: MasterRecord

--- a/pages/empi/merge.vue
+++ b/pages/empi/merge.vue
@@ -34,10 +34,33 @@
         </div>
       </div>
 
-      <div class="flex-none h-8 lg:w-8 mb-2">
-        <button v-tooltip="'Switch Records'" class="block mx-auto" @click="switchRecords">
-          <IconSwitchH class="hidden lg:block" /><IconSwitchV class="block lg:hidden" />
-        </button>
+      <div class="flex-none flex flex-row lg:flex-col my-4 lg:my-0 lg:w-8 mb-2 justify-center lg:justify-start">
+        <div class="flex-shrink">
+          <button
+            v-tooltip="'Switch Records'"
+            class="
+              w-8
+              block
+              mx-auto
+              rounded-md
+              shadow-sm
+              font-medium
+              focus:outline-none focus:ring-2 focus:ring-offset-2
+              border
+              bg-white
+              hover:bg-gray-50
+              focus:ring-indigo-500
+              border-gray-300
+              text-gray-700
+            "
+            @click="switchRecords"
+          >
+            <IconSwitchH class="hidden lg:block my-2" /><IconSwitchV class="block lg:hidden my-2" />
+          </button>
+        </div>
+        <div class="hidden lg:flex flex-col flex-grow justify-center">
+          <div class="h-8"><IconArrowRight /></div>
+        </div>
       </div>
 
       <div class="flex-1">

--- a/pages/masterrecords/_id/linkrecords.vue
+++ b/pages/masterrecords/_id/linkrecords.vue
@@ -1,22 +1,13 @@
 <template>
   <div>
     <LoadingIndicator v-if="$fetchState.pending"></LoadingIndicator>
-    <div v-else class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+    <div v-else class="grid grid-cols-1 gap-6">
       <div v-for="link in linkRecords" :key="link.id">
         <TextL1 class="mb-2 w-full text-center">Link Record {{ link.id }}</TextL1>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-6">
-          <PersonsRecordCard
-            class="border-2 border-red-500"
-            :record="link.person"
-            :label="`Person ${link.person.id.toString()}`"
-          />
-
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <PersonsRecordCard class="border-2 border-red-500" :record="link.person" />
           <NuxtLink :to="`/masterrecords/${link.masterRecord.id}`">
-            <masterrecordsRecordCard
-              class="border-2 border-indigo-500"
-              :record="link.masterRecord"
-              :label="`Master Record ${link.masterRecord.id.toString()}`"
-            />
+            <masterrecordsRecordCard class="border-2 border-indigo-500" :record="link.masterRecord" />
           </NuxtLink>
         </div>
       </div>

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -113,49 +113,66 @@
     </GenericCard>
 
     <!-- Work Item Trigger -->
-    <div v-if="record" class="flex">
-      <TextH2 class="flex-grow mb-4">Work Item Trigger</TextH2>
-      <div class="flex-shrink">
-        <GenericButtonMini @click="showDestinationPersons = !showDestinationPersons">
-          {{ showDestinationPersons ? 'Show Destination Master Record' : 'Show Related Person Records' }}
-        </GenericButtonMini>
-      </div>
+    <div v-if="record" class="flex mb-4">
+      <TextH2>Work Item Trigger</TextH2>
     </div>
 
-    <div v-if="record && record.destination.persons.length > 0" class="mb-8">
-      <div v-if="record.destination.persons.length > 0" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <!-- Type 9 incoming attribute card -->
-        <WorkitemsAttributeRecordCard
-          v-if="record.type === 9"
-          class="border-2 border-green-500"
-          :record="record.attributes"
-          label="Incoming Attributes"
-          :highlight="Object.keys(record.attributes)"
-        />
-        <!-- Else incoming person card -->
-        <personsRecordCard
-          v-else-if="record.incoming.person"
-          class="border-2 border-red-500"
-          :record="record.person"
-          :label="`Incoming Person Record ${record.incoming.person.id}`"
-          :highlight="Object.keys(record.attributes)"
-        />
-        <!-- Missing incoming person card -->
-        <div v-else class="rounded-md bg-red-50 font-medium text-red-800 p-4">No incoming Person record</div>
-        <!-- Destination person card -->
-        <personsRecordCard
-          v-if="showDestinationPersons"
-          :record="record.destination.persons[relatedPersonsIndex]"
-          :label="`Related Person Record ${relatedPersonsIndex + 1} of ${record.destination.persons.length}`"
-          :highlight="Object.keys(record.attributes)"
-        />
-        <NuxtLink v-else :to="`/masterrecords/${record.destination.masterRecord.id}`">
-          <masterrecordsRecordCard
-            class="border-2 border-indigo-500"
-            :record="record.destination.masterRecord"
-            :label="`Destination Master Record ${record.destination.masterRecord.id}`"
+    <div v-if="record" class="mb-8">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div id="incomingCard">
+          <!-- Attribute toggle -->
+          <GenericTabToggle
+            v-model="showIncomingAttributes"
+            true-label="Attributes"
+            false-label="Person Record"
+            class="mb-2"
           />
-        </NuxtLink>
+          <!-- Type 9 incoming attribute card -->
+          <WorkitemsAttributeRecordCard
+            v-if="showIncomingAttributes"
+            class="border-2 border-green-500"
+            :record="record.attributes"
+            label="Incoming Attributes"
+            :highlight="Object.keys(record.attributes)"
+            :full="showDestinationPersons"
+          />
+          <!-- Else incoming person card -->
+          <personsRecordCard
+            v-else-if="record.incoming.person"
+            class="border-2 border-red-500"
+            :record="record.person"
+            :label="`Incoming Person Record ${record.incoming.person.id}`"
+            :highlight="Object.keys(record.attributes)"
+            :full="showDestinationPersons"
+          />
+          <!-- Missing incoming person card -->
+          <div v-else class="rounded-md bg-red-50 font-medium text-red-800 p-4">No incoming Person record</div>
+        </div>
+
+        <div id="destinationCard">
+          <!-- Destination toggle -->
+          <GenericTabToggle
+            v-model="showDestinationPersons"
+            true-label="Related Persons"
+            false-label="Destination Master Record"
+            class="mb-2"
+          />
+          <!-- Destination person card -->
+          <personsRecordCard
+            v-if="showDestinationPersons && record.destination.persons.length > 0"
+            :record="record.destination.persons[relatedPersonsIndex]"
+            :label="`Related Person Record ${relatedPersonsIndex + 1} of ${record.destination.persons.length}`"
+            :highlight="Object.keys(record.attributes)"
+            :full="true"
+          />
+          <NuxtLink v-else :to="`/masterrecords/${record.destination.masterRecord.id}`">
+            <masterrecordsRecordCard
+              class="border-2 border-indigo-500"
+              :record="record.destination.masterRecord"
+              :label="`Destination Master Record ${record.destination.masterRecord.id}`"
+            />
+          </NuxtLink>
+        </div>
       </div>
       <GenericCard v-if="showDestinationPersons && record.destination.persons.length > 1" class="pl-4 mt-2">
         <GenericItemPaginator
@@ -171,17 +188,9 @@
 
       <div v-if="record" class="mb-8">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <!-- Type 9 incoming attribute card -->
-          <WorkitemsAttributeRecordCard
-            v-if="record.type === 9"
-            class="border-2 border-green-500"
-            :record="record.attributes"
-            label="Incoming Attributes"
-            :highlight="Object.keys(record.attributes)"
-          />
           <!-- Incoming records card -->
           <NuxtLink
-            v-else-if="record.incoming.masterRecords.length > 0"
+            v-if="record.incoming.masterRecords.length > 0"
             :to="`/masterrecords/${record.incoming.masterRecords[relatedRecordsIndex].id}`"
           >
             <masterrecordsRecordCard
@@ -274,6 +283,7 @@ export default defineComponent({
     })
 
     // Dynamic UI
+    const showIncomingAttributes = ref(false)
     const showDestinationPersons = ref(false)
     const availableActions = computed<AvailableActions>(() => {
       return {
@@ -381,6 +391,7 @@ export default defineComponent({
       addCommentModal,
       closeModal,
       closeMessageOverride,
+      showIncomingAttributes,
       showDestinationPersons,
       updateWorkItemComment,
       closeWorkItem,

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -137,7 +137,7 @@
           v-else-if="record.incoming.person"
           class="border-2 border-red-500"
           :record="record.person"
-          label="Incoming Person Record"
+          :label="`Incoming Person Record ${record.incoming.person.id}`"
           :highlight="Object.keys(record.attributes)"
         />
         <!-- Missing incoming person card -->
@@ -153,7 +153,7 @@
           <masterrecordsRecordCard
             class="border-2 border-indigo-500"
             :record="record.destination.masterRecord"
-            label="Destination Master Record"
+            :label="`Destination Master Record ${record.destination.masterRecord.id}`"
           />
         </NuxtLink>
       </div>

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -44,7 +44,7 @@
     </div>
 
     <!-- Info Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 md:gap-4 mb-8">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
       <!-- Work Item Details -->
       <WorkitemsDetailCard :item="record" />
       <!-- Work Item Advice -->

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -113,18 +113,14 @@
     </GenericCard>
 
     <!-- Work Item Trigger -->
-    <div v-if="record" class="flex mb-4">
-      <TextH2>Work Item Trigger</TextH2>
-    </div>
-
     <div v-if="record" class="mb-8">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div id="incomingCard">
           <!-- Attribute toggle -->
           <GenericTabToggle
             v-model="showIncomingAttributes"
-            true-label="Attributes"
-            false-label="Person Record"
+            true-label="Incoming Attributes"
+            false-label="Incoming Person Record"
             class="mb-2"
           />
           <!-- Type 9 incoming attribute card -->
@@ -153,7 +149,7 @@
           <!-- Destination toggle -->
           <GenericTabToggle
             v-model="showDestinationPersons"
-            true-label="Related Persons"
+            true-label="Related Person Records"
             false-label="Destination Master Record"
             class="mb-2"
           />

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -282,7 +282,7 @@ export default defineComponent({
         comment: true,
         // We can only merge if we have an incoming Master Record, and both
         // incoming and destination records are UKRDC type
-        merge: workItemIsMergable(record.value),
+        merge: record.value ? workItemIsMergable(record.value) : false,
         // Currently Unlink never makes sense, so ignore for now. Maybe remove entirely?
         unlink: false,
       } as AvailableActions

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
     variants: {
       extend: {
         opacity: ['disabled'],
+        textDecoration: ['focus-visible'],
       },
     },
   },

--- a/utilities/workItemUtils.ts
+++ b/utilities/workItemUtils.ts
@@ -1,0 +1,10 @@
+import { WorkItemExtended } from '~/interfaces/workitem'
+
+export function workItemIsMergable(item: WorkItemExtended | undefined) {
+  return (
+    item &&
+    item.type !== 9 &&
+    item.incoming.masterRecords.length > 0 &&
+    item.destination.masterRecord.nationalidType === 'UKRDC'
+  )
+}

--- a/utilities/workItemUtils.ts
+++ b/utilities/workItemUtils.ts
@@ -79,3 +79,12 @@ export function collectionIsUnresolved(related: WorkItem[]) {
   }
   return false
 }
+
+export function formatAttributeValue(attributeString: String) {
+  const splitString = attributeString.split(':')
+  if (splitString.length > 1) {
+    return `${attributeString.split(':')[0]} → ${attributeString.split(':')[1]}`
+  } else {
+    return attributeString.split(':')[0]
+  }
+}

--- a/utilities/workItemUtils.ts
+++ b/utilities/workItemUtils.ts
@@ -1,10 +1,81 @@
-import { WorkItemExtended } from '~/interfaces/workitem'
+/* 
+USEFUL RULES FOR WORKITEMS
 
-export function workItemIsMergable(item: WorkItemExtended | undefined) {
-  return (
-    item &&
-    item.type !== 9 &&
-    item.incoming.masterRecords.length > 0 &&
-    item.destination.masterRecord.nationalidType === 'UKRDC'
-  )
+Type 9:
+- Person ID always 999999999, no real incoming Person record
+- WorkItem based entirely on attributes + "destination" master record
+- Always an NHS/CHI/HSC destination record
+
+Type 7:
+- Always an NHS/CHI/HSC destination record
+- Usually raised in a pair with a type 6
+  - The type 7 is not mergable, and should be closed after the type 6 is merged
+
+Type 6:
+- Always a UKRDC destination record
+- Usually raised in a pair with a type 7 
+  - The type 6 is mergable (both incoming and destination are UKRDC records)
+
+Type 4:
+- Always an NHS/CHI/HSC destination record
+- Usually raised in a pair with a type 3
+  - The type 4 is not mergable, and should be closed after the type 3 is merged
+
+Type 3:
+- Always a UKRDC destination record
+- Usually raised in a pair with a type 4
+  - The type 3 is mergable (both incoming and destination are UKRDC records)
+
+
+NOMENCLATURE:
+
+I'm considering a "secondary" workitem as one in a collection of workitems raised
+by the same event, which requires others in the collection to be resolved before closing.
+
+I'm considering a "primary" workitem as one in a collection of workitems raised
+by the same event, which can be resolved without the others.
+
+*/
+
+import { WorkItem, WorkItemExtended } from '~/interfaces/workitem'
+
+export function workItemIsOpen(item: WorkItem): Boolean {
+  return item?.status !== 3
+}
+
+export function workItemIsUKRDC(item: WorkItem) {
+  return item?.type === 3 || item?.type === 6
+}
+
+export function workItemIsMergable(item: WorkItemExtended): Boolean {
+  // Check if a workitem can be merged (incoming and destination UKRDC records)
+  return workItemIsUKRDC(item) && item.incoming.masterRecords.length > 0
+}
+
+export function workItemIsSecondary(item: WorkItemExtended, related: WorkItem[]) {
+  // Check if a workitem should be treated as secondary to others in the collection
+  if (workItemIsMergable(item)) {
+    // Mergable workitems are always "primary"
+    return false
+  }
+  // For each related Work Item in the collection
+  for (const relatedItem of related) {
+    // If the related Work Item is a mergable UKRDC Work Item
+    if (workItemIsUKRDC(relatedItem) && workItemIsOpen(relatedItem)) {
+      return true
+    }
+  }
+  // If no items in the collection need to be resolved, this is a "primary" workitem
+  return false
+}
+
+export function collectionIsUnresolved(related: WorkItem[]) {
+  // For each related Work Item in the collection
+  for (const relatedItem of related) {
+    // If the related Work Item is a mergable UKRDC Work Item
+    if (workItemIsOpen(relatedItem)) {
+      return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
- [x] Add a card for workitem advice
- [x] Rearrange workitem incoming and destination cards
- [x] Only show proposed merge on relevant work items
- [x] Include record IDs on cards
- [x] Overhaul advice logic
  - See meeting notes
- [x] Restyle "switch" button in merge UI to be clearer
- [x] Add a "what triggered this workitem" button to open a modal showing all attributes on the workitem
