### PR TITLE
Hash in container

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -47,4 +47,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_REF=${{ github.ref }}
           tags: ghcr.io/renalreg/ukrdc-nuxt:${{github.event.inputs.deployment_env}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:16-alpine
 
+ARG GITHUB_SHA
+ARG GITHUB_REF
+
+ENV GITHUB_SHA=$GITHUB_SHA \
+    GITHUB_REF=$GITHUB_REF
+
 WORKDIR /app
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
Adds functionality to include GitHub commit hash and ref to container environment variables. This will be used in an upcoming system info/debug page.