### PR TITLE
Render record data asynchronously

### DIFF
--- a/components/generic/alert/Placeholder.vue
+++ b/components/generic/alert/Placeholder.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="rounded-md border border-gray-400 p-4">
+    <div class="flex items-center">
+      <!-- Heroicon name: solid/information-circle -->
+      <svg
+        class="h-5 w-5 text-gray-400 flex-shrink-0"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+          clip-rule="evenodd"
+        />
+      </svg>
+      <div class="ml-3 flex-1 md:flex md:justify-between">
+        <p class="text-gray-700">Loading data. Please wait...</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/masterrecords/index.vue
+++ b/pages/masterrecords/index.vue
@@ -82,7 +82,7 @@ export default defineComponent({
     // Data fetching
 
     async function getResults() {
-      if (searchQueryIsPopulated) {
+      if (searchQueryIsPopulated.value) {
         const resultsPage = await fetchSearchResultsPage(
           apiQueryString.value,
           page.value || 0,

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -100,23 +100,6 @@
       </GenericButton>
     </div>
 
-    <!-- Related Work Items  -->
-    <GenericCard v-if="workItemCollection.length > 0" class="mb-8">
-      <!-- Card header -->
-      <GenericCardHeader>
-        <TextH2>Related Work Items</TextH2>
-        <TextL2>Work Items for the same patient, raised by the same event</TextL2>
-      </GenericCardHeader>
-      <!-- Results list -->
-      <ul class="divide-y divide-gray-200">
-        <div v-for="item in workItemCollection" :key="item.id" :item="item" class="hover:bg-gray-50">
-          <NuxtLink :to="`/workitems/${item.id}`">
-            <workitemsListItem :item="item" />
-          </NuxtLink>
-        </div>
-      </ul>
-    </GenericCard>
-
     <!-- Work Item Trigger -->
     <div v-if="record" class="mb-8">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -219,6 +202,23 @@
         /></GenericCard>
       </div>
     </div>
+
+    <!-- Related Work Items  -->
+    <GenericCard v-if="workItemCollection.length > 0" class="mb-8">
+      <!-- Card header -->
+      <GenericCardHeader>
+        <TextH2>Related Work Items</TextH2>
+        <TextL2>Work Items for the same patient, raised by the same event</TextL2>
+      </GenericCardHeader>
+      <!-- Results list -->
+      <ul class="divide-y divide-gray-200">
+        <div v-for="item in workItemCollection" :key="item.id" :item="item" class="hover:bg-gray-50">
+          <NuxtLink :to="`/workitems/${item.id}`">
+            <workitemsListItem :item="item" />
+          </NuxtLink>
+        </div>
+      </ul>
+    </GenericCard>
 
     <!-- Related errors card -->
     <WorkitemsRelatedErrorsList v-if="record" class="mt-4 mb-8" :workitem="record" :size="5" />


### PR DESCRIPTION
Improved loading performance of records significantly.

Previous code would load all record resources in parallel, but wait for all to complete before assigning responses to data values. This held up page rendering in cases where one resource is slower than the others (common for the latest_message resource for example).

By moving back to classic JS promise syntax we get much faster loading of basic record data.

Also fixes an unrelated issue causing pointless search requests to be sent