### PR TITLE
Pagination and query improvements

### DIFF
--- a/components/empi/Search.vue
+++ b/components/empi/Search.vue
@@ -80,7 +80,7 @@ export default defineComponent({
       if (searchQueryIsPopulated) {
         const results = await fetchSearchResultsPage(
           apiQueryString.value,
-          page.value || 0,
+          page.value || 1,
           size.value,
           true,
           props.onlyUkrdc

--- a/components/empi/Search.vue
+++ b/components/empi/Search.vue
@@ -48,7 +48,7 @@ Mini (half-width) search bar and results pages used in the EMPI Merge page.
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import usePagination from '~/helpers/query/usePagination'
 import { MasterRecord } from '@/interfaces/masterrecord'
@@ -67,8 +67,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const route = useRoute()
-
     const { page, total, size } = usePagination()
     const { showUKRDC } = useUserPrefs()
     const { searchQueryIsPopulated, searchboxString, searchSubmit, apiQueryString } = useRecordSearch()
@@ -97,7 +95,7 @@ export default defineComponent({
       fetchResults()
     })
 
-    watch([route, showUKRDC], () => {
+    watch([apiQueryString, page, showUKRDC], () => {
       fetchResults()
     })
 

--- a/helpers/query/usePagination.ts
+++ b/helpers/query/usePagination.ts
@@ -12,6 +12,7 @@ export default function () {
     console.warn('changePage is deprecated. Directly set page value instead')
     page.value = newPage
   }
+
   return {
     page,
     total,

--- a/helpers/query/useRecordSearch.ts
+++ b/helpers/query/useRecordSearch.ts
@@ -1,9 +1,7 @@
-import { computed, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { computed, onMounted, ref, watch } from '@nuxtjs/composition-api'
 import useQuery from '~/helpers/query/useQuery'
 
 export default function () {
-  const route = useRoute()
-
   const { arrayQuery } = useQuery()
 
   // Array of individual search terms as an array of strings from the URL query
@@ -104,7 +102,7 @@ export default function () {
     return buildAPIQueryStringFromArray(searchTermArray.value)
   })
 
-  watch([route], () => {
+  watch(searchTermArray, () => {
     searchApply()
   })
 

--- a/pages/codes.vue
+++ b/pages/codes.vue
@@ -89,7 +89,7 @@ export default defineComponent({
 
     // Data fetching
     async function getCodes() {
-      const codesPage = await fetchCodesPage(page.value || 0, size.value, selectedStandard.value, searchboxString.value)
+      const codesPage = await fetchCodesPage(page.value || 1, size.value, selectedStandard.value, searchboxString.value)
       codes.value = codesPage.items
       total.value = codesPage.total
       page.value = codesPage.page

--- a/pages/codes/_id.vue
+++ b/pages/codes/_id.vue
@@ -102,9 +102,12 @@ export default defineComponent({
       getCode()
     })
 
-    watch(route, () => {
-      getCode()
-    })
+    watch(
+      () => route.value.params.id,
+      () => {
+        getCode()
+      }
+    )
 
     // External code links
 

--- a/pages/masterrecords/_id/audit.vue
+++ b/pages/masterrecords/_id/audit.vue
@@ -77,7 +77,7 @@ export default defineComponent({
     async function fetchEvents() {
       const eventsPage = await fetchMasterRecordAuditPage(
         props.record,
-        page.value || 0,
+        page.value || 1,
         size.value,
         orderBy.value,
         dateRange.value.start,

--- a/pages/masterrecords/_id/audit.vue
+++ b/pages/masterrecords/_id/audit.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { nowString } from '@/helpers/utils/dateUtils'
 import usePagination from '~/helpers/query/usePagination'
@@ -59,8 +59,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const route = useRoute()
-
     const { page, total, size } = usePagination()
     const { makeDateRange } = useDateRange()
     const { orderAscending, orderBy, toggleOrder } = useSortBy()
@@ -94,7 +92,7 @@ export default defineComponent({
       fetchEvents()
     })
 
-    watch(route, () => {
+    watch([page, dateRange, orderBy], () => {
       fetchEvents()
     })
 

--- a/pages/masterrecords/_id/issues.vue
+++ b/pages/masterrecords/_id/issues.vue
@@ -92,7 +92,7 @@ export default defineComponent({
     async function updateRelatedErrors(): Promise<void> {
       const res = await fetchMasterRecordMessagesPage(
         props.record,
-        relatedErrorsPage.value || 0,
+        relatedErrorsPage.value || 1,
         relatedErrorsSize.value,
         'desc',
         ['ERROR'], // Status filter

--- a/pages/masterrecords/_id/messages.vue
+++ b/pages/masterrecords/_id/messages.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { nowString } from '@/helpers/utils/dateUtils'
 import usePagination from '~/helpers/query/usePagination'
@@ -66,8 +66,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const route = useRoute()
-
     const { page, total, size } = usePagination()
     const { makeDateRange } = useDateRange()
     const { orderAscending, orderBy, toggleOrder } = useSortBy()
@@ -102,7 +100,7 @@ export default defineComponent({
       fetchMessages()
     })
 
-    watch(route, () => {
+    watch([page, dateRange, orderBy], () => {
       fetchMessages()
     })
 

--- a/pages/masterrecords/_id/messages.vue
+++ b/pages/masterrecords/_id/messages.vue
@@ -84,7 +84,7 @@ export default defineComponent({
     async function fetchMessages() {
       const messagesPage = await fetchMasterRecordMessagesPage(
         props.record,
-        page.value || 0,
+        page.value || 1,
         size.value,
         orderBy.value,
         [], // Status filter

--- a/pages/masterrecords/index.vue
+++ b/pages/masterrecords/index.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { MasterRecord } from '@/interfaces/masterrecord'
 import usePagination from '~/helpers/query/usePagination'
@@ -69,8 +69,6 @@ import fetchSearchResults from '~/helpers/fetch/fetchSearchResults'
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-
     const { page, total, size } = usePagination()
     const { showUKRDC } = useUserPrefs()
     const { searchQueryIsPopulated, searchboxString, searchSubmit, apiQueryString } = useRecordSearch()
@@ -92,8 +90,8 @@ export default defineComponent({
         )
 
         masterrecords.value = resultsPage.items
-        total.value = resultsPage.total
         page.value = resultsPage.page
+        total.value = resultsPage.total
         size.value = resultsPage.size
       }
     }
@@ -102,7 +100,7 @@ export default defineComponent({
       getResults()
     })
 
-    watch([route, showUKRDC], () => {
+    watch([apiQueryString, page, showUKRDC], () => {
       getResults()
     })
 

--- a/pages/masterrecords/index.vue
+++ b/pages/masterrecords/index.vue
@@ -86,7 +86,7 @@ export default defineComponent({
       if (searchQueryIsPopulated.value) {
         const resultsPage = await fetchSearchResultsPage(
           apiQueryString.value,
-          page.value || 0,
+          page.value || 1,
           size.value,
           showUKRDC.value
         )

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { nowString } from '@/helpers/utils/dateUtils'
 import { Message } from '@/interfaces/messages'
@@ -88,8 +88,6 @@ import fetchMessages from '~/helpers/fetch/fetchMessages'
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-
     const { page, total, size } = usePagination()
     const { makeDateRange } = useDateRange()
     const { stringQuery, arrayQuery } = useQuery()
@@ -130,7 +128,7 @@ export default defineComponent({
       getMessages()
     })
 
-    watch(route, () => {
+    watch([page, orderBy, statuses, dateRange, selectedFacility, nationalId], () => {
       getMessages()
     })
 

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -111,7 +111,7 @@ export default defineComponent({
     // Data fetching
     async function getMessages() {
       const messagesPage = await fetchMessagesPage(
-        page.value || 0,
+        page.value || 1,
         size.value,
         orderBy.value,
         statuses.value, // Status filter

--- a/pages/patientrecords/_pid/documents/index.vue
+++ b/pages/patientrecords/_pid/documents/index.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     // Data fetching
 
     async function getDocuments() {
-      const documentsPage = await fetchPatientRecordDocumentsPage(props.record, page.value || 0, size.value)
+      const documentsPage = await fetchPatientRecordDocumentsPage(props.record, page.value || 1, size.value)
       documents.value = documentsPage.items
       total.value = documentsPage.total
       page.value = documentsPage.page

--- a/pages/patientrecords/_pid/documents/index.vue
+++ b/pages/patientrecords/_pid/documents/index.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { PatientRecord } from '@/interfaces/patientrecord'
 import { PatientDocumentSummary } from '@/interfaces/document'
@@ -49,7 +49,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const route = useRoute()
     const { page, total, size } = usePagination()
     const { makeDateRange } = useDateRange()
     const { fetchPatientRecordDocumentsPage } = fetchPatientRecords()
@@ -75,7 +74,7 @@ export default defineComponent({
       getDocuments()
     })
 
-    watch(route, () => {
+    watch(page, () => {
       getDocuments()
     })
 

--- a/pages/patientrecords/_pid/laborders.vue
+++ b/pages/patientrecords/_pid/laborders.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     // Data fetching
 
     async function fetchOrders() {
-      const ordersPage = await fetchPatientRecordLabOrdersPage(props.record, page.value || 0, size.value)
+      const ordersPage = await fetchPatientRecordLabOrdersPage(props.record, page.value || 1, size.value)
       orders.value = ordersPage.items
       total.value = ordersPage.total
       page.value = ordersPage.page

--- a/pages/patientrecords/_pid/laborders.vue
+++ b/pages/patientrecords/_pid/laborders.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { formatDate } from '@/helpers/utils/dateUtils'
 
@@ -49,7 +49,6 @@ export default defineComponent({
   },
 
   setup(props) {
-    const route = useRoute()
     const { page, total, size } = usePagination()
     const { fetchPatientRecordLabOrdersPage } = fetchPatientRecords()
 
@@ -71,7 +70,7 @@ export default defineComponent({
       fetchOrders()
     })
 
-    watch(route, () => {
+    watch([page], () => {
       fetchOrders()
     })
 

--- a/pages/patientrecords/_pid/observations.vue
+++ b/pages/patientrecords/_pid/observations.vue
@@ -96,14 +96,6 @@ export default defineComponent({
     // Data fetching
 
     async function fetchObservations() {
-      let path = `${props.record.links.observations}?page=${page.value}&size=${size.value}`
-
-      for (const code of selectedCodes.value) {
-        if (code) {
-          path = path + `&code=${code}`
-        }
-      }
-
       const observationsPage = await fetchPatientRecordObservationsPage(
         props.record,
         page.value || 1,
@@ -125,7 +117,7 @@ export default defineComponent({
       fetchObservations()
     })
 
-    watch(route, () => {
+    watch([page, selectedCodes], () => {
       fetchObservations()
     })
 

--- a/pages/patientrecords/_pid/observations.vue
+++ b/pages/patientrecords/_pid/observations.vue
@@ -106,7 +106,7 @@ export default defineComponent({
 
       const observationsPage = await fetchPatientRecordObservationsPage(
         props.record,
-        page.value || 0,
+        page.value || 1,
         size.value,
         selectedCodes.value
       )

--- a/pages/patientrecords/_pid/results.vue
+++ b/pages/patientrecords/_pid/results.vue
@@ -141,7 +141,7 @@ export default defineComponent({
     async function fetchResults() {
       const resultsPage = await fetchPatientRecordResultsPage(
         props.record,
-        page.value || 0,
+        page.value || 1,
         size.value,
         selectedService.value,
         selectedOrderId.value,

--- a/pages/patientrecords/_pid/results.vue
+++ b/pages/patientrecords/_pid/results.vue
@@ -94,7 +94,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useContext, useRoute, watch } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useContext, watch } from '@nuxtjs/composition-api'
 
 import { PatientRecord } from '@/interfaces/patientrecord'
 import { LabOrder, ResultItem } from '@/interfaces/laborder'
@@ -116,7 +116,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const route = useRoute()
     const { $toast } = useContext()
     const { page, total, size } = usePagination()
     const { makeDateRange } = useDateRange()
@@ -217,16 +216,6 @@ export default defineComponent({
       }
     }
 
-    onMounted(() => {
-      fetchResults()
-      fetchLabOrder()
-    })
-
-    watch(route, () => {
-      fetchResults()
-      fetchLabOrder()
-    })
-
     // Result item services
 
     const availableServicesMap = ref([] as ResultService[])
@@ -244,6 +233,21 @@ export default defineComponent({
     // Lab order filter
 
     const selectedOrderId = stringQuery('order_id', null, true, true)
+
+    // Data lifecycle
+
+    onMounted(() => {
+      fetchResults()
+      fetchLabOrder()
+    })
+
+    watch([page, selectedService, selectedOrderId, dateRange], () => {
+      fetchResults()
+    })
+
+    watch(selectedOrderId, () => {
+      fetchLabOrder()
+    })
 
     return {
       page,

--- a/pages/workitems/index.vue
+++ b/pages/workitems/index.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
 
 import { WorkItem } from '@/interfaces/workitem'
 import usePagination from '~/helpers/query/usePagination'
@@ -72,8 +72,6 @@ import useDateRange from '~/helpers/query/useDateRange'
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-
     const { page, total, size } = usePagination()
     const { makeDateRange } = useDateRange()
     const { arrayQuery } = useQuery()
@@ -103,8 +101,8 @@ export default defineComponent({
       )
 
       workitems.value = itemsPage.items
-      total.value = itemsPage.total
       page.value = itemsPage.page
+      total.value = itemsPage.total
       size.value = itemsPage.size
     }
 
@@ -112,7 +110,7 @@ export default defineComponent({
       getWorkitems()
     })
 
-    watch(route, () => {
+    watch([page, dateRange, statuses, selectedFacility, orderBy], () => {
       getWorkitems()
     })
 

--- a/pages/workitems/index.vue
+++ b/pages/workitems/index.vue
@@ -93,7 +93,7 @@ export default defineComponent({
 
     async function getWorkitems() {
       const itemsPage = await fetchWorkItemsPage(
-        page.value || 0,
+        page.value || 1,
         size.value,
         orderBy.value || 'desc',
         statuses.value,


### PR DESCRIPTION
The main point of this PR is to fix the long-running issue of listed requests being sent twice.

Previously, opening a page would send the initial list request, fetch the data, and then based on the returned `page` number set the `page` query parameter. This allows us to guarantee the request and page queries are identical and in sync. However, since we watch the `page` query to trigger new requests, this causes the initial request to be run again.

Until now this wasn't really an issue, as it was fast enough and only happened once per page, however now we're auditing all requests this would mean we get double audit rows.

In this PR, we stop watching `route` and instead watch the `page` computed property. Since the computed property has a default value, the initial request no longer changes it's value, and thus prevents duplicated requests.