### PR TITLE
Multiple UKRDC ID viewer

### DIFF
--- a/components/empi/Search.vue
+++ b/components/empi/Search.vue
@@ -17,12 +17,7 @@ Mini (half-width) search bar and results pages used in the EMPI Merge page.
         <!-- Real results -->
         <ul v-else class="divide-y divide-gray-200">
           <div v-for="item in masterrecords" :key="item.id" class="hover:bg-gray-50">
-            <MasterrecordsListItem
-              class="cursor-pointer"
-              :item="item"
-              :show-record-id="false"
-              @click.native="$emit('select', item.id)"
-            />
+            <MasterrecordsListItem class="cursor-pointer" :item="item" @click.native="$emit('select', item.id)" />
           </div>
         </ul>
         <GenericPaginator

--- a/components/masterrecords/ListItem.vue
+++ b/components/masterrecords/ListItem.vue
@@ -1,10 +1,7 @@
 <template>
   <li>
     <!-- Content container -->
-    <div
-      class="px-4 py-4 sm:px-6 min-w-0 grid grid-cols-3 md:gap-4 w-full"
-      :class="showRecordId ? 'lg:grid-cols-4' : 'col-span-2'"
-    >
+    <div class="px-4 py-4 sm:px-6 min-w-0 grid grid-cols-3 lg:grid-cols-4 md:gap-4 w-full">
       <!-- Name, DoB, gender -->
       <div>
         <TextNameL1 :forename="item.givenname" :surname="item.surname" />
@@ -13,8 +10,8 @@
           <b class="ml-1"> {{ formatGenderCharacter(item.gender) }}</b>
         </TextP>
       </div>
-      <!-- Record ID (large breakpoint only) -->
-      <div v-show="showRecordId" class="hidden lg:block">
+      <!-- Record ID (large breakpoint only if a detail column is given) -->
+      <div :class="detailsValue ? 'hidden lg:block' : ''">
         <TextL1>Record ID</TextL1>
         <TextP class="mt-2">
           {{ item.id }}
@@ -27,11 +24,11 @@
         </TextP>
         <masterrecordsNationalIdTypeTag class="mt-2" :nationalid-type="item.nationalidType" />
       </div>
-      <!-- Details  -->
-      <div>
-        <TextL1>Last updated</TextL1>
+      <!-- Details, defaults to record updated time, but can be overridden by props  -->
+      <div v-if="detailsValue">
+        <TextL1>{{ detailsLabel }}</TextL1>
         <TextP class="mt-2">
-          {{ formatDate(item.lastUpdated) }}
+          {{ detailsValue }}
         </TextP>
       </div>
     </div>
@@ -50,10 +47,20 @@ export default defineComponent({
       type: Object as () => MasterRecord,
       required: true,
     },
-    showRecordId: {
-      type: Boolean,
+
+    // Override details data label
+    // E.g. in lists of records where we want a different timestamp shown,
+    // such as the multiple UKRDC ID viewer, where we show the last checked time.
+    detailsLabel: {
+      type: String,
       required: false,
-      default: true,
+      default: 'Details',
+    },
+    // Override details data value, see above
+    detailsValue: {
+      type: String,
+      required: false,
+      default: null,
     },
   },
 

--- a/helpers/fetch/fetchCodes.ts
+++ b/helpers/fetch/fetchCodes.ts
@@ -1,4 +1,4 @@
-import { ref, useContext } from '@nuxtjs/composition-api'
+import { useContext } from '@nuxtjs/composition-api'
 import { Code, ExtendedCode } from '@/interfaces/codes'
 
 interface CodesPage {
@@ -17,15 +17,12 @@ export default function () {
     return standardsResponse
   }
 
-  const fetchInProgress = ref(false)
-
   async function fetchCodesPage(
     page: number,
     size: number,
     standard: string | null,
     search: string | null
   ): Promise<CodesPage> {
-    fetchInProgress.value = true
     // Fetch code list
     let path = `${$config.apiBase}/v1/codes/list/?page=${page}&size=${size}`
     // Filter by service if it exists
@@ -36,14 +33,12 @@ export default function () {
     if (search) {
       path = path + `&search=${encodeURIComponent(search)}`
     }
-    const codesResponse = (await $axios.$get(path)) as CodesPage
-    fetchInProgress.value = false
-    return codesResponse
+    return (await $axios.$get(path)) as CodesPage
   }
 
   async function fetchCode(code: string): Promise<ExtendedCode> {
     return (await $axios.$get(`${$config.apiBase}/v1/codes/list/${code}/`)) as ExtendedCode
   }
 
-  return { fetchCodingStandards, fetchCodesPage, fetchCode, fetchInProgress }
+  return { fetchCodingStandards, fetchCodesPage, fetchCode }
 }

--- a/helpers/fetch/fetchDataHealth.ts
+++ b/helpers/fetch/fetchDataHealth.ts
@@ -1,0 +1,23 @@
+import { useContext } from '@nuxtjs/composition-api'
+import { MasterRecord } from '~/interfaces/masterrecord'
+
+export interface MultipleUKRDCIDsPage {
+  items: MasterRecord[][]
+  total: number
+  page: number
+  size: number
+}
+
+export default function () {
+  const { $axios, $config } = useContext()
+
+  async function fetchMultipleUKRDCIDsPage(page: number, size: number): Promise<MultipleUKRDCIDsPage> {
+    return (await $axios.$get(
+      `${$config.apiBase}/v1/admin/datahealth/multiple_ukrdcids/?page=${page}&size=${size}`
+    )) as MultipleUKRDCIDsPage
+  }
+
+  return {
+    fetchMultipleUKRDCIDsPage,
+  }
+}

--- a/helpers/fetch/fetchDataHealth.ts
+++ b/helpers/fetch/fetchDataHealth.ts
@@ -1,12 +1,5 @@
 import { useContext } from '@nuxtjs/composition-api'
-import { MasterRecord } from '~/interfaces/masterrecord'
-
-export interface MultipleUKRDCIDsPage {
-  items: MasterRecord[][]
-  total: number
-  page: number
-  size: number
-}
+import { MultipleUKRDCIDsPage } from '~/interfaces/datahealth'
 
 export default function () {
   const { $axios, $config } = useContext()

--- a/helpers/fetch/fetchMessages.ts
+++ b/helpers/fetch/fetchMessages.ts
@@ -8,8 +8,6 @@ import { WorkItem } from '~/interfaces/workitem'
 export default function () {
   const { $axios, $config } = useContext()
 
-  const fetchInProgress = ref(false)
-
   async function fetchMessagesPage(
     page: number,
     size: number,
@@ -34,9 +32,7 @@ export default function () {
       path = path + `&ni=${nationalId}`
     }
 
-    fetchInProgress.value = true
     const response: MessagePage = await $axios.$get(path)
-    fetchInProgress.value = false
     return response
   }
 
@@ -88,7 +84,6 @@ export default function () {
   }
 
   return {
-    fetchInProgress,
     fetchMessagesPage,
     fetchMessage,
     fetchMessageMasterRecords,

--- a/helpers/fetch/fetchWorkItems.ts
+++ b/helpers/fetch/fetchWorkItems.ts
@@ -1,4 +1,4 @@
-import { ref, useContext } from '@nuxtjs/composition-api'
+import { useContext } from '@nuxtjs/composition-api'
 import { buildCommonMessageQuery, MessagePage, buildCommonDateRangeQuery } from './common'
 import { WorkItem, WorkItemExtended } from '~/interfaces/workitem'
 
@@ -11,8 +11,6 @@ interface WorkItemPage {
 
 export default function () {
   const { $axios, $config } = useContext()
-
-  const fetchInProgress = ref(false)
 
   async function fetchWorkItemsPage(
     page: number,
@@ -35,10 +33,7 @@ export default function () {
     // Filter by since-until if it exists
     path = path + buildCommonDateRangeQuery(since, until)
 
-    fetchInProgress.value = true
-    const response: WorkItemPage = await $axios.$get(path)
-    fetchInProgress.value = false
-    return response
+    return await $axios.$get(path)
   }
 
   async function fetchWorkItem(id: string): Promise<WorkItemExtended> {
@@ -77,7 +72,6 @@ export default function () {
   }
 
   return {
-    fetchInProgress,
     fetchWorkItemsPage,
     fetchWorkItem,
     closeWorkItem,

--- a/interfaces/datahealth.ts
+++ b/interfaces/datahealth.ts
@@ -1,0 +1,18 @@
+import { MasterRecord } from './masterrecord'
+
+interface MultipleUKRDCIDsGroupItem {
+  lastUpdated: string
+  masterRecord: MasterRecord
+}
+
+export interface MultipleUKRDCIDsGroup {
+  groupId: number
+  records: MultipleUKRDCIDsGroupItem[]
+}
+
+export interface MultipleUKRDCIDsPage {
+  items: MultipleUKRDCIDsGroup[]
+  total: number
+  page: number
+  size: number
+}

--- a/pages/codes.vue
+++ b/pages/codes.vue
@@ -75,7 +75,7 @@ export default defineComponent({
   setup() {
     const { page, total, size } = usePagination()
     const { stringQuery } = useQuery()
-    const { fetchCodingStandards, fetchCodesPage, fetchInProgress } = fetchCodes()
+    const { fetchCodingStandards, fetchCodesPage } = fetchCodes()
 
     // Data refs
 
@@ -87,13 +87,19 @@ export default defineComponent({
 
     const searchboxString = stringQuery('search', null, true, true)
 
+    const fetchInProgress = ref(false)
+
     // Data fetching
     async function getCodes() {
+      fetchInProgress.value = true
+
       const codesPage = await fetchCodesPage(page.value || 1, size.value, selectedStandard.value, searchboxString.value)
       codes.value = codesPage.items
       total.value = codesPage.total
       page.value = codesPage.page
       size.value = codesPage.size
+
+      fetchInProgress.value = false
     }
 
     onMounted(async () => {

--- a/pages/empi/index.vue
+++ b/pages/empi/index.vue
@@ -1,20 +1,21 @@
 <template>
   <div>
-    <TextH1 class="mb-6">EMPI Management</TextH1>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <TextH2 class="mb-4">EMPI Management</TextH2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
       <EmpiQuickLink
         title="Merge"
         description="Merge Master Records within the EMPI, moving all Patient Records to a combined Master Record"
         icon="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
         :href="'/empi/merge'"
       />
+    </div>
+    <TextH2 class="mb-4">EMPI Health</TextH2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
       <EmpiQuickLink
-        class="hidden"
-        title="Unlink"
-        description="Unlink Person Records and Patient Records from their Master Records within the EMPI"
-        icon="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
-        :href="'/empi/unlink'"
+        title="Multiple UKRDC IDs"
+        description="View and manage patients with multiple UKRDC IDs"
+        icon="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+        :href="'/empi/multipleids'"
       />
     </div>
   </div>

--- a/pages/empi/multipleids.vue
+++ b/pages/empi/multipleids.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <div class="max-w-7xl mx-auto mb-4">
+      <TextH1>Multiple UKRDC IDs</TextH1>
+    </div>
+    <div v-if="groups">
+      <div v-for="(group, index) in groups" :key="`group-${index}`">
+        <GenericCard class="mb-6">
+          <ul class="divide-y divide-gray-200">
+            <div v-for="item in group" :key="item.id" class="hover:bg-gray-50">
+              <NuxtLink :to="`/masterrecords/${item.id}`">
+                <MasterrecordsListItem :item="item" />
+              </NuxtLink>
+            </div>
+          </ul>
+        </GenericCard>
+      </div>
+
+      <GenericCard>
+        <GenericPaginator
+          class="bg-white"
+          :page="page"
+          :size="size"
+          :total="total"
+          @next="page++"
+          @prev="page--"
+          @jump="page = $event"
+        />
+      </GenericCard>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+
+import { MasterRecord } from '@/interfaces/masterrecord'
+import usePagination from '~/helpers/query/usePagination'
+
+import fetchDataHealth from '~/helpers/fetch/fetchDataHealth'
+
+export default defineComponent({
+  setup() {
+    const { page, total, size } = usePagination()
+    const { fetchMultipleUKRDCIDsPage } = fetchDataHealth()
+
+    // Data refs
+    size.value = 10 // Get 10 groups as we expect a couple of records per group
+    const groups = ref<MasterRecord[][]>()
+
+    // Data fetching
+    async function getGroups() {
+      const groupsPage = await fetchMultipleUKRDCIDsPage(page.value || 1, size.value)
+      groups.value = groupsPage.items
+      total.value = groupsPage.total
+      page.value = groupsPage.page
+      size.value = groupsPage.size
+    }
+
+    onMounted(() => {
+      getGroups()
+    })
+
+    watch(page, () => {
+      getGroups()
+    })
+
+    return {
+      groups,
+      page,
+      total,
+      size,
+    }
+  },
+})
+</script>

--- a/pages/empi/multipleids.vue
+++ b/pages/empi/multipleids.vue
@@ -1,15 +1,30 @@
 <template>
   <div>
-    <div class="max-w-7xl mx-auto mb-4">
+    <div class="max-w-7xl mx-auto mb-6">
       <TextH1>Multiple UKRDC IDs</TextH1>
+      <TextP>Results of a scan that detect patients with more than one UKRDC Master Record.</TextP>
+      <TextP>
+        New results are identified weekly, but existing results are re-checked hourly, see <b>Last checked</b>.
+      </TextP>
+      <TextP> Resolved items will remain in this view until the next check. </TextP>
     </div>
+
     <div v-if="groups">
-      <div v-for="(group, index) in groups" :key="`group-${index}`">
-        <GenericCard class="mb-6">
+      <div v-for="group in groups" :key="`group-${group.groupId}`">
+        <GenericCard class="mb-8">
           <ul class="divide-y divide-gray-200">
-            <div v-for="item in group" :key="item.id" class="hover:bg-gray-50">
-              <NuxtLink :to="`/masterrecords/${item.id}`">
-                <MasterrecordsListItem :item="item" />
+            <div
+              v-for="item in group.records"
+              :key="`record-${group.groupId}-${item.masterRecord.id}`"
+              class="hover:bg-gray-50"
+            >
+              <SkeleListItem v-if="fetchInProgress" />
+              <NuxtLink v-else :to="`/masterrecords/${item.masterRecord.id}`">
+                <MasterrecordsListItem
+                  :item="item.masterRecord"
+                  details-label="Last checked"
+                  :details-value="formatDate(item.lastUpdated)"
+                />
               </NuxtLink>
             </div>
           </ul>
@@ -28,13 +43,15 @@
         />
       </GenericCard>
     </div>
+    <LoadingIndicator v-else></LoadingIndicator>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { formatDate } from '@/helpers/utils/dateUtils'
 
-import { MasterRecord } from '@/interfaces/masterrecord'
+import { MultipleUKRDCIDsGroup } from '@/interfaces/datahealth'
 import usePagination from '~/helpers/query/usePagination'
 
 import fetchDataHealth from '~/helpers/fetch/fetchDataHealth'
@@ -46,15 +63,21 @@ export default defineComponent({
 
     // Data refs
     size.value = 10 // Get 10 groups as we expect a couple of records per group
-    const groups = ref<MasterRecord[][]>()
+
+    const groups = ref<MultipleUKRDCIDsGroup[]>()
+    const fetchInProgress = ref(false)
 
     // Data fetching
     async function getGroups() {
+      fetchInProgress.value = true
+
       const groupsPage = await fetchMultipleUKRDCIDsPage(page.value || 1, size.value)
       groups.value = groupsPage.items
       total.value = groupsPage.total
       page.value = groupsPage.page
       size.value = groupsPage.size
+
+      fetchInProgress.value = false
     }
 
     onMounted(() => {
@@ -67,9 +90,11 @@ export default defineComponent({
 
     return {
       groups,
+      fetchInProgress,
       page,
       total,
       size,
+      formatDate,
     }
   },
 })

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -137,9 +137,7 @@ export default defineComponent({
         () => JSON.stringify(dateRange), // Stringify to watch for actual value changes
         () => JSON.stringify(statuses), // Stringify to watch for actual value changes
       ],
-      (current, old) => {
-        console.log(current)
-        console.log(old)
+      () => {
         getMessages()
       }
     )

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -93,7 +93,7 @@ export default defineComponent({
     const { stringQuery, arrayQuery } = useQuery()
     const { facilities, facilityIds, facilityLabels, selectedFacility } = useFacilities()
     const { orderAscending, orderBy, toggleOrder } = useSortBy()
-    const { fetchInProgress, fetchMessagesPage } = fetchMessages()
+    const { fetchMessagesPage } = fetchMessages()
 
     // Set up URL query params for additional filters
     const nationalId = stringQuery('nationalid', null, true, true)
@@ -106,8 +106,12 @@ export default defineComponent({
     const messages = ref<Message[]>()
     const statuses = arrayQuery('status', ['ERROR'], true, true)
 
+    const fetchInProgress = ref(false)
+
     // Data fetching
     async function getMessages() {
+      fetchInProgress.value = true
+
       const messagesPage = await fetchMessagesPage(
         page.value || 1,
         size.value,
@@ -122,6 +126,8 @@ export default defineComponent({
       total.value = messagesPage.total
       page.value = messagesPage.page
       size.value = messagesPage.size
+
+      fetchInProgress.value = false
     }
 
     onMounted(() => {

--- a/pages/workitems/index.vue
+++ b/pages/workitems/index.vue
@@ -77,12 +77,14 @@ export default defineComponent({
     const { arrayQuery } = useQuery()
     const { facilities, facilityIds, facilityLabels, selectedFacility } = useFacilities()
     const { orderAscending, orderBy, toggleOrder } = useSortBy()
-    const { fetchInProgress, fetchWorkItemsPage } = fetchWorkItems()
+    const { fetchWorkItemsPage } = fetchWorkItems()
 
     // Data refs
 
     const workitems = ref<WorkItem[]>()
     const statuses = arrayQuery('status', ['1'], true, true)
+
+    const fetchInProgress = ref(false)
 
     // Set initial date dateRange
     const dateRange = makeDateRange(null, null, true, true)
@@ -90,6 +92,8 @@ export default defineComponent({
     // Data fetching
 
     async function getWorkitems() {
+      fetchInProgress.value = true
+
       const itemsPage = await fetchWorkItemsPage(
         page.value || 1,
         size.value,
@@ -104,6 +108,8 @@ export default defineComponent({
       page.value = itemsPage.page
       total.value = itemsPage.total
       size.value = itemsPage.size
+
+      fetchInProgress.value = false
     }
 
     onMounted(() => {


### PR DESCRIPTION
Frontend counterpart to https://github.com/renalreg/ukrdc-fastapi/pull/242

Depends on https://github.com/renalreg/ukrdc-fastapi/pull/244

Adds a basic viewer for records with multiple UKRDC IDs

## Todo

- [x] Add explanation of the data to the top of the page
- [x] Add list item placeholders