### PR TITLE
Remove @nuxt/tailwindcss and reset prettier config to default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,10 @@ module.exports = {
     node: true,
   },
   // Extend prettier config to disable rules that conflict with prettier
-  extends: ['@nuxtjs/eslint-config-typescript', 'prettier', 'plugin:nuxt/recommended'],
+  extends: ["@nuxtjs/eslint-config-typescript", "prettier", "plugin:nuxt/recommended"],
   // add your custom rules here
   rules: {
-    'no-console': 'off',
-    'vue/multi-word-component-names': 'off',
+    "no-console": "off",
+    "vue/multi-word-component-names": "off",
   },
-}
+};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,3 @@
 {
-  "semi": false,
-  "singleQuote": true,
   "printWidth": 120
 }

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ It may be simpler to start a fresh Nuxt 3 project and add the application back i
 - Phase 2: Migrate to [Nuxt 3](https://v3.nuxtjs.org/guide/getting-started/)
   - Wait for nuxtjs/axios module to support Nuxt 3 (or replace with normal Axios and a custom plugin)
     - See https://github.com/nuxt-community/axios-module/issues/536
-  - Replace Tailwind module with "normal" Tailwind
-    - See https://github.com/nuxt-community/tailwindcss-module/issues/387
+  - Replace/remove @nuxt/postcss8
+    - See https://tailwindcss.com/docs/guides/nuxtjs and https://stackoverflow.com/questions/70302520/nuxtjs-v3-and-tailwindcss-v3-postcss8-not-compatible
   - Update requirements to Vue 3 compatible versions
     - `v-calendar` to `v-calendar@next`
     - `v-tooltip` to `v-tooltip@vue3`

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/components/LoadingIndicator.vue
+++ b/components/LoadingIndicator.vue
@@ -7,17 +7,17 @@
 </template>
 
 <script>
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
     colour: {
       type: String,
-      default: 'indigo',
+      default: "indigo",
     },
   },
   setup() {},
-})
+});
 </script>
 
 <style lang="postcss" scoped>

--- a/components/LoadingIndicatorFull.vue
+++ b/components/LoadingIndicatorFull.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -20,5 +20,5 @@ export default defineComponent({
     },
   },
   setup() {},
-})
+});
 </script>

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -38,13 +38,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
     value: {
       type: String,
-      default: '',
+      default: "",
     },
     focus: {
       type: Boolean,
@@ -57,5 +57,5 @@ export default defineComponent({
       default: true,
     },
   },
-})
+});
 </script>

--- a/components/admin/Dashboard.vue
+++ b/components/admin/Dashboard.vue
@@ -88,62 +88,62 @@ Admin (permission ukrdc:facilities:*) dashboard with overview of all facilities.
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useRouter } from '@nuxtjs/composition-api'
-import { HistoryItem } from '~/interfaces/common'
-import { HistoryPointEvent } from '~/interfaces/charts'
-import fetchAdmin from '@/helpers/fetch/fetchAdmin'
-import { getPointDateRange } from '@/helpers/utils/chartUtils'
-import { AdminCounts } from '~/interfaces/admin'
+import { defineComponent, onMounted, ref, useRouter } from "@nuxtjs/composition-api";
+import { HistoryItem } from "~/interfaces/common";
+import { HistoryPointEvent } from "~/interfaces/charts";
+import fetchAdmin from "@/helpers/fetch/fetchAdmin";
+import { getPointDateRange } from "@/helpers/utils/chartUtils";
+import { AdminCounts } from "~/interfaces/admin";
 
 export default defineComponent({
   setup() {
-    const router = useRouter()
-    const { fetchWorkItemsHistory, fetchErrorsHistory, fetchAdminCounts } = fetchAdmin()
+    const router = useRouter();
+    const { fetchWorkItemsHistory, fetchErrorsHistory, fetchAdminCounts } = fetchAdmin();
 
-    const errorsHistory = ref<HistoryItem[]>()
-    const workitemsHistory = ref<HistoryItem[]>()
-    const counts = ref<AdminCounts>()
+    const errorsHistory = ref<HistoryItem[]>();
+    const workitemsHistory = ref<HistoryItem[]>();
+    const counts = ref<AdminCounts>();
 
     function fetchAdminDashboard() {
       fetchWorkItemsHistory(null, null).then((response: HistoryItem[]) => {
-        workitemsHistory.value = response
-      })
+        workitemsHistory.value = response;
+      });
       fetchErrorsHistory(null, null).then((response: HistoryItem[]) => {
-        errorsHistory.value = response
-      })
+        errorsHistory.value = response;
+      });
       fetchAdminCounts().then((response: AdminCounts) => {
-        counts.value = response
-      })
+        counts.value = response;
+      });
     }
 
     // History plot click handler
 
     function errorHistoryPointClickHandler(point: HistoryPointEvent) {
-      const pointRange = getPointDateRange(point)
+      const pointRange = getPointDateRange(point);
       router.push({
-        path: '/messages',
+        path: "/messages",
         query: {
           since: pointRange.since,
           until: pointRange.until,
-          status: ['ERROR', 'RESOLVED'],
+          status: ["ERROR", "RESOLVED"],
         },
-      })
+      });
     }
 
     function workitemHistoryPointClickHandler(point: HistoryPointEvent) {
-      const pointRange = getPointDateRange(point)
+      const pointRange = getPointDateRange(point);
       router.push({
-        path: '/workitems',
+        path: "/workitems",
         query: {
           since: pointRange.since,
           until: pointRange.until,
         },
-      })
+      });
     }
 
     onMounted(() => {
-      fetchAdminDashboard()
-    })
+      fetchAdminDashboard();
+    });
 
     return {
       errorsHistory,
@@ -151,7 +151,7 @@ export default defineComponent({
       counts,
       errorHistoryPointClickHandler,
       workitemHistoryPointClickHandler,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/audit/ListItem.vue
+++ b/components/audit/ListItem.vue
@@ -33,9 +33,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { AuditEvent } from '@/interfaces/audit'
+import { defineComponent, ref } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { AuditEvent } from "@/interfaces/audit";
 
 export default defineComponent({
   props: {
@@ -55,8 +55,8 @@ export default defineComponent({
     },
   },
   setup(_) {
-    const showChildren = ref(false)
-    return { showChildren, formatDate }
+    const showChildren = ref(false);
+    return { showChildren, formatDate };
   },
-})
+});
 </script>

--- a/components/audit/ResourceBadge.vue
+++ b/components/audit/ResourceBadge.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref } from "@nuxtjs/composition-api";
 
-import { AuditEvent } from '~/interfaces/audit'
+import { AuditEvent } from "~/interfaces/audit";
 
 export default defineComponent({
   props: {
@@ -24,29 +24,29 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const clickUrl = ref<string | null>(null)
+    const clickUrl = ref<string | null>(null);
 
     const resourceName = computed(() => {
-      return props.item.resource.replace('_', ' ').trim()
-    })
+      return props.item.resource.replace("_", " ").trim();
+    });
 
     const primaryIdentifier = computed(() => {
       if (props.item.identifiers.length > 0) {
-        return props.item.identifiers[0]
+        return props.item.identifiers[0];
       } else {
-        return props.item.resourceId
+        return props.item.resourceId;
       }
-    })
+    });
 
     function identifier(index: number) {
       if (props.item.identifiers.length > index) {
-        return props.item.identifiers[index]
+        return props.item.identifiers[index];
       } else {
-        return ''
+        return "";
       }
     }
 
-    return { resourceName, primaryIdentifier, identifier, clickUrl }
+    return { resourceName, primaryIdentifier, identifier, clickUrl };
   },
-})
+});
 </script>

--- a/components/badge/Crud.vue
+++ b/components/badge/Crud.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -20,20 +20,20 @@ export default defineComponent({
 
   setup() {
     function TagClass(operation: string): string[] {
-      if (operation.includes('DELETE')) {
-        return ['bg-red-100', 'text-red-800']
-      } else if (operation.includes('READ')) {
-        return ['bg-blue-100', 'text-blue-800']
-      } else if (operation.includes('UPDATE')) {
-        return ['bg-purple-100', 'text-purple-800']
-      } else if (operation.includes('CREATE')) {
-        return ['bg-green-100', 'text-green-800']
+      if (operation.includes("DELETE")) {
+        return ["bg-red-100", "text-red-800"];
+      } else if (operation.includes("READ")) {
+        return ["bg-blue-100", "text-blue-800"];
+      } else if (operation.includes("UPDATE")) {
+        return ["bg-purple-100", "text-purple-800"];
+      } else if (operation.includes("CREATE")) {
+        return ["bg-green-100", "text-green-800"];
       } else {
-        return ['bg-gray-100', 'text-gray-800']
+        return ["bg-gray-100", "text-gray-800"];
       }
     }
 
-    return { TagClass }
+    return { TagClass };
   },
-})
+});
 </script>

--- a/components/chart/Doughnut.vue
+++ b/components/chart/Doughnut.vue
@@ -5,11 +5,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted } from "@nuxtjs/composition-api";
 
-import { ArcElement, Chart, DoughnutController } from 'chart.js'
+import { ArcElement, Chart, DoughnutController } from "chart.js";
 
-Chart.register(DoughnutController, ArcElement)
+Chart.register(DoughnutController, ArcElement);
 
 export default defineComponent({
   props: {
@@ -33,9 +33,9 @@ export default defineComponent({
 
   setup(props) {
     onMounted(() => {
-      const canvas = document.getElementById('doughnut') as HTMLCanvasElement
+      const canvas = document.getElementById("doughnut") as HTMLCanvasElement;
       const options = {
-        type: 'doughnut',
+        type: "doughnut",
         data: {
           datasets: [
             {
@@ -47,10 +47,10 @@ export default defineComponent({
           labels: props.labels,
         },
         options: props.options,
-      }
+      };
       // @ts-ignore
-      return new Chart(canvas, options)
-    })
+      return new Chart(canvas, options);
+    });
   },
-})
+});
 </script>

--- a/components/chart/TimeSeries.vue
+++ b/components/chart/TimeSeries.vue
@@ -5,21 +5,21 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { Interval, DateTime } from 'luxon'
+import { Interval, DateTime } from "luxon";
 
-import { Chart, LineController, TimeScale, LinearScale, PointElement, LineElement, Tooltip } from 'chart.js'
-import 'chartjs-adapter-luxon'
+import { Chart, LineController, TimeScale, LinearScale, PointElement, LineElement, Tooltip } from "chart.js";
+import "chartjs-adapter-luxon";
 
-import { HistoryItem } from '~/interfaces/common'
+import { HistoryItem } from "~/interfaces/common";
 
-Chart.register(LineController, TimeScale, LinearScale, PointElement, LineElement, Tooltip)
+Chart.register(LineController, TimeScale, LinearScale, PointElement, LineElement, Tooltip);
 
 interface EventElement {
-  datasetIndex: number
-  element: PointElement
-  index: number
+  datasetIndex: number;
+  element: PointElement;
+  index: number;
 }
 
 export default defineComponent({
@@ -30,7 +30,7 @@ export default defineComponent({
     },
     label: {
       type: String,
-      default: '',
+      default: "",
     },
     options: {
       type: Object,
@@ -42,7 +42,7 @@ export default defineComponent({
     },
     id: {
       type: String,
-      default: 'time-series',
+      default: "time-series",
     },
     start: {
       type: String,
@@ -57,44 +57,44 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
-    const dataToUse = ref<{ [key: string]: number }>({})
+    const dataToUse = ref<{ [key: string]: number }>({});
 
     function* iterateDays(interval: Interval) {
-      let cursor = interval.start.startOf('day')
+      let cursor = interval.start.startOf("day");
       while (cursor < interval.end) {
-        yield cursor
-        cursor = cursor.plus({ days: 1 })
+        yield cursor;
+        cursor = cursor.plus({ days: 1 });
       }
     }
 
     function populateData() {
       // Populate base/missing data
       if (props.autofillData) {
-        const start = props.start ? DateTime.fromISO(props.start) : DateTime.now().minus({ days: 365 })
-        const end = props.end ? DateTime.fromISO(props.end) : DateTime.now()
-        const interval = Interval.fromDateTimes(start, end)
+        const start = props.start ? DateTime.fromISO(props.start) : DateTime.now().minus({ days: 365 });
+        const end = props.end ? DateTime.fromISO(props.end) : DateTime.now();
+        const interval = Interval.fromDateTimes(start, end);
         for (const d of iterateDays(interval)) {
-          dataToUse.value[d.toISODate()] = 0
+          dataToUse.value[d.toISODate()] = 0;
         }
       }
 
       // Populate real data
       for (const item of props.data) {
-        dataToUse.value[item.time] = item.count
+        dataToUse.value[item.time] = item.count;
       }
     }
 
     onMounted(() => {
-      populateData()
-      const canvas = document.getElementById(props.id) as HTMLCanvasElement
+      populateData();
+      const canvas = document.getElementById(props.id) as HTMLCanvasElement;
       const options = {
-        type: 'line',
+        type: "line",
         data: {
           datasets: [
             {
               data: dataToUse.value,
-              borderColor: 'rgba(79, 70, 229, 1)',
-              backgroundColor: 'rgba(79, 70, 229, 0.5)',
+              borderColor: "rgba(79, 70, 229, 1)",
+              backgroundColor: "rgba(79, 70, 229, 0.5)",
               pointRadius: 0,
               hitRadius: 5,
               hoverRadius: 5,
@@ -104,29 +104,29 @@ export default defineComponent({
         options: {
           onClick: (_: MouseEvent, activeElements: EventElement[]) => {
             if (activeElements && activeElements[0]) {
-              const pointEl = activeElements[0].element
+              const pointEl = activeElements[0].element;
               // @ts-ignore
               // TODO: We only used to need pointEl.parsed, but as of chart.js 3.7.0,
               // it's always returning undefined. pointEl.$context.parsed seems to work,
               // but it's not documented, and doesn't appear in the TypeScript definitions,
               // so we'll just use it for now and ignore TS for this line.
-              const parsed = pointEl.parsed || pointEl.$context.parsed
-              emit('click', parsed)
+              const parsed = pointEl.parsed || pointEl.$context.parsed;
+              emit("click", parsed);
             }
           },
           responsive: true,
           maintainAspectRatio: false,
           scales: {
             x: {
-              type: 'time',
+              type: "time",
               time: {
-                format: 'YYYY-MM-DD',
+                format: "YYYY-MM-DD",
                 displayFormats: {
-                  quarter: 'MMM YYYY',
+                  quarter: "MMM YYYY",
                 },
               },
               ticks: {
-                source: 'auto',
+                source: "auto",
                 autoSkip: true,
               },
             },
@@ -142,12 +142,12 @@ export default defineComponent({
             },
           },
         },
-      }
+      };
       // @ts-ignore
-      return new Chart(canvas, options)
-    })
+      return new Chart(canvas, options);
+    });
 
-    return { dataToUse }
+    return { dataToUse };
   },
-})
+});
 </script>

--- a/components/codes/ListItem.vue
+++ b/components/codes/ListItem.vue
@@ -9,16 +9,16 @@ Single item of the codes list used in the Codes page.
       <div class="col-span-2">
         <CodesTitle :code="code.code" :coding-standard="code.codingStandard" />
         <TextP class="mt-2 truncate">
-          {{ code.description || 'No description found' }}
+          {{ code.description || "No description found" }}
         </TextP>
       </div>
       <!-- Extra fields  -->
       <div class="col-span-1 hidden lg:block">
         <div>
-          <TextL1 class="inline">Type: </TextL1><TextP class="inline">{{ code.objectType || 'None' }} </TextP>
+          <TextL1 class="inline">Type: </TextL1><TextP class="inline">{{ code.objectType || "None" }} </TextP>
         </div>
         <div class="mt-2">
-          <TextL1 class="inline">Units: </TextL1><TextP class="inline">{{ code.units || 'None' }} </TextP>
+          <TextL1 class="inline">Units: </TextL1><TextP class="inline">{{ code.units || "None" }} </TextP>
         </div>
       </div>
     </div>
@@ -26,8 +26,8 @@ Single item of the codes list used in the Codes page.
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { Code } from '@/interfaces/codes'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { Code } from "@/interfaces/codes";
 
 export default defineComponent({
   props: {
@@ -36,5 +36,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/codes/MapListItem.vue
+++ b/components/codes/MapListItem.vue
@@ -17,8 +17,8 @@ Basic code map description, used in the maps sections of a Code pane.
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { CodeMap } from '@/interfaces/codes'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { CodeMap } from "@/interfaces/codes";
 
 export default defineComponent({
   props: {
@@ -27,5 +27,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/codes/Title.vue
+++ b/components/codes/Title.vue
@@ -12,7 +12,7 @@ Re-usable formatted code title component.
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -25,5 +25,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/empi/MultipleIDItem.vue
+++ b/components/empi/MultipleIDItem.vue
@@ -46,10 +46,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { MultipleUKRDCIDsGroup } from '@/interfaces/datahealth'
+import { MultipleUKRDCIDsGroup } from "@/interfaces/datahealth";
 
 export default defineComponent({
   props: {
@@ -71,7 +71,7 @@ export default defineComponent({
   setup() {
     return {
       formatDate,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/empi/QuickLink.vue
+++ b/components/empi/QuickLink.vue
@@ -3,7 +3,7 @@ Big link cards used in the EMPI page, to direct to Merge etc.
 -->
 
 <template>
-  <GenericCard class="group focus-within:ring-cyan-500 relative p-6 focus-within:ring-2 focus-within:ring-inset">
+  <GenericCard class="group relative p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-cyan-500">
     <div>
       <span class="inline-flex rounded-lg bg-indigo-50 p-3 text-indigo-700 ring-4 ring-white">
         <!-- Heroicon name: outline/link -->
@@ -42,7 +42,7 @@ Big link cards used in the EMPI page, to direct to Merge etc.
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -64,5 +64,5 @@ export default defineComponent({
     },
   },
   setup() {},
-})
+});
 </script>

--- a/components/empi/Search.vue
+++ b/components/empi/Search.vue
@@ -43,15 +43,15 @@ Mini (half-width) search bar and results pages used in the EMPI Merge page.
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import usePagination from '~/helpers/query/usePagination'
-import { MasterRecord } from '@/interfaces/masterrecord'
+import usePagination from "~/helpers/query/usePagination";
+import { MasterRecord } from "@/interfaces/masterrecord";
 
-import useUserPrefs from '~/helpers/useUserPrefs'
-import useRecordSearch from '~/helpers/query/useRecordSearch'
+import useUserPrefs from "~/helpers/useUserPrefs";
+import useRecordSearch from "~/helpers/query/useRecordSearch";
 
-import fetchSearchResults from '~/helpers/fetch/fetchSearchResults'
+import fetchSearchResults from "~/helpers/fetch/fetchSearchResults";
 
 export default defineComponent({
   props: {
@@ -62,12 +62,12 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { page, total, size } = usePagination()
-    const { showUKRDC } = useUserPrefs()
-    const { searchQueryIsPopulated, searchboxString, searchSubmit, apiQueryString } = useRecordSearch()
-    const { fetchSearchResultsPage, searchInProgress } = fetchSearchResults()
+    const { page, total, size } = usePagination();
+    const { showUKRDC } = useUserPrefs();
+    const { searchQueryIsPopulated, searchboxString, searchSubmit, apiQueryString } = useRecordSearch();
+    const { fetchSearchResultsPage, searchInProgress } = fetchSearchResults();
 
-    const masterrecords = ref([] as MasterRecord[])
+    const masterrecords = ref([] as MasterRecord[]);
 
     async function fetchResults() {
       if (searchQueryIsPopulated) {
@@ -77,22 +77,22 @@ export default defineComponent({
           size.value,
           true,
           props.onlyUkrdc
-        )
+        );
 
-        masterrecords.value = results.items
-        total.value = results.total
-        page.value = results.page
-        size.value = results.size
+        masterrecords.value = results.items;
+        total.value = results.total;
+        page.value = results.page;
+        size.value = results.size;
       }
     }
 
     onMounted(() => {
-      fetchResults()
-    })
+      fetchResults();
+    });
 
     watch([apiQueryString, page, showUKRDC], () => {
-      fetchResults()
-    })
+      fetchResults();
+    });
 
     return {
       masterrecords,
@@ -104,10 +104,10 @@ export default defineComponent({
       page,
       size,
       total,
-    }
+    };
   },
   head: {
-    title: 'Master Records',
+    title: "Master Records",
   },
-})
+});
 </script>

--- a/components/facilities/Overview.vue
+++ b/components/facilities/Overview.vue
@@ -131,7 +131,7 @@ page (for multi-facility users), and the homepage (for single-facility users).
             </TextDt>
             <TextDd>
               <div v-if="facility && facility.dataFlow.pkbMessageExclusions.length > 0" class="flex items-center gap-2">
-                <div>{{ facility.dataFlow.pkbMessageExclusions.join(', ') }}</div>
+                <div>{{ facility.dataFlow.pkbMessageExclusions.join(", ") }}</div>
               </div>
               <div v-else>None</div>
             </TextDd>
@@ -183,18 +183,18 @@ page (for multi-facility users), and the homepage (for single-facility users).
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useRouter, watch } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useRouter, watch } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { Facility } from '~/interfaces/facilities'
-import { HistoryItem } from '~/interfaces/common'
+import { Facility } from "~/interfaces/facilities";
+import { HistoryItem } from "~/interfaces/common";
 
-import fetchFacilities from '~/helpers/fetch/fetchFacilities'
-import { Message } from '~/interfaces/messages'
-import { HistoryPointEvent } from '~/interfaces/charts'
+import fetchFacilities from "~/helpers/fetch/fetchFacilities";
+import { Message } from "~/interfaces/messages";
+import { HistoryPointEvent } from "~/interfaces/charts";
 
-import { getPointDateRange } from '@/helpers/utils/chartUtils'
+import { getPointDateRange } from "@/helpers/utils/chartUtils";
 
 export default defineComponent({
   props: {
@@ -204,39 +204,39 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const router = useRouter()
-    const { fetchFacility, fetchFacilityErrorsHistory, fetchFacilityPatientsLatestErrorsPage } = fetchFacilities()
+    const router = useRouter();
+    const { fetchFacility, fetchFacilityErrorsHistory, fetchFacilityPatientsLatestErrorsPage } = fetchFacilities();
 
-    const facility = ref<Facility>()
-    const facilityErrorsHistory = ref<HistoryItem[]>()
+    const facility = ref<Facility>();
+    const facilityErrorsHistory = ref<HistoryItem[]>();
 
     // Computed string for statistics last updated time
     const lastUpdatedString = computed(() => {
       if (!facility.value) {
-        return ''
+        return "";
       }
-      return formatDate(facility.value.statistics.lastUpdated, true)
-    })
+      return formatDate(facility.value.statistics.lastUpdated, true);
+    });
 
     // Failing NIs data
-    const errorMessages = ref([] as Message[])
-    const errorMessagesPage = ref(1)
-    const errorMessagesSize = ref(5)
-    const errorMessagesTotal = ref(0)
+    const errorMessages = ref([] as Message[]);
+    const errorMessagesPage = ref(1);
+    const errorMessagesSize = ref(5);
+    const errorMessagesTotal = ref(0);
 
     // History plot click handler
 
     function historyPointClickHandler(point: HistoryPointEvent) {
-      const pointRange = getPointDateRange(point)
+      const pointRange = getPointDateRange(point);
       router.push({
-        path: '/messages',
+        path: "/messages",
         query: {
           since: pointRange.since,
           until: pointRange.until,
           facility: props.code,
-          status: ['ERROR', 'RESOLVED'],
+          status: ["ERROR", "RESOLVED"],
         },
-      })
+      });
     }
 
     // Data fetching
@@ -248,32 +248,32 @@ export default defineComponent({
           errorMessagesPage.value,
           errorMessagesSize.value,
           null
-        )
+        );
         // Set related errors
-        errorMessages.value = errorsPage.items
-        errorMessagesPage.value = errorsPage.page
-        errorMessagesSize.value = errorsPage.size
-        errorMessagesTotal.value = errorsPage.total
+        errorMessages.value = errorsPage.items;
+        errorMessagesPage.value = errorsPage.page;
+        errorMessagesSize.value = errorsPage.size;
+        errorMessagesTotal.value = errorsPage.total;
       }
     }
 
     async function updateErrorsHistory(): Promise<void> {
       if (facility.value) {
-        facilityErrorsHistory.value = await fetchFacilityErrorsHistory(facility.value)
+        facilityErrorsHistory.value = await fetchFacilityErrorsHistory(facility.value);
       }
     }
 
     onMounted(() => {
       fetchFacility(props.code).then((response) => {
-        facility.value = response
-        updateErrorMessages()
-        updateErrorsHistory()
-      })
-    })
+        facility.value = response;
+        updateErrorMessages();
+        updateErrorsHistory();
+      });
+    });
 
     watch(errorMessagesPage, () => {
-      updateErrorMessages()
-    })
+      updateErrorMessages();
+    });
 
     return {
       lastUpdatedString,
@@ -284,7 +284,7 @@ export default defineComponent({
       errorMessagesSize,
       errorMessagesTotal,
       historyPointClickHandler,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/facilities/Table.vue
+++ b/components/facilities/Table.vue
@@ -69,7 +69,7 @@ Table of facilities and their basic statistics
           <GenericTableCell>
             <div class="flex items-center">
               <IconCircle class="inline" :class="facility.dataFlow.pkbOut ? 'text-green-600' : 'text-red-700'" />
-              <p>{{ facility.dataFlow.pkbOut ? 'Yes' : 'No' }}</p>
+              <p>{{ facility.dataFlow.pkbOut ? "Yes" : "No" }}</p>
             </div>
           </GenericTableCell>
         </tr>
@@ -79,12 +79,12 @@ Table of facilities and their basic statistics
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
-import fetchFacilities from '~/helpers/fetch/fetchFacilities'
-import { Facility } from '~/interfaces/facilities'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
+import fetchFacilities from "~/helpers/fetch/fetchFacilities";
+import { Facility } from "~/interfaces/facilities";
 
 interface IsAscending {
-  [key: string]: boolean | null
+  [key: string]: boolean | null;
 }
 
 export default defineComponent({
@@ -97,17 +97,17 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { fetchFacilitiesList } = fetchFacilities()
+    const { fetchFacilitiesList } = fetchFacilities();
 
     // Facility list and filters
 
-    const facilities = ref<Facility[]>()
-    const searchboxString = ref('')
+    const facilities = ref<Facility[]>();
+    const searchboxString = ref("");
 
-    const filterByPkbOut = ref(false)
+    const filterByPkbOut = ref(false);
 
     const filteredFacilities = computed(() => {
-      if (!facilities.value) return []
+      if (!facilities.value) return [];
       return (
         facilities.value
           // Filter by search term
@@ -118,37 +118,37 @@ export default defineComponent({
           )
           // Filter by additional filters, such as PkbOut
           .filter((option) => (filterByPkbOut.value ? option.dataFlow.pkbOut : true))
-      )
-    })
+      );
+    });
 
     // Sorting
 
-    const sortBy = ref<string | null>(null)
+    const sortBy = ref<string | null>(null);
 
     // Set initial order for id sorting. Other columns left as default
     const isAscending = ref<IsAscending>({
       id: true,
-    })
+    });
 
     async function fetchTable() {
-      const currentisAscending: null | boolean = isAscending.value[sortBy.value || 'default'] || null
-      const currentOrderBy: string = currentisAscending ? 'asc' : 'desc'
-      facilities.value = await fetchFacilitiesList(sortBy.value, currentOrderBy, props.includeEmpty)
+      const currentisAscending: null | boolean = isAscending.value[sortBy.value || "default"] || null;
+      const currentOrderBy: string = currentisAscending ? "asc" : "desc";
+      facilities.value = await fetchFacilitiesList(sortBy.value, currentOrderBy, props.includeEmpty);
     }
 
     async function toggleSort(key: string) {
       // Only reverse order if we're sorting by this key already
       if (sortBy.value === key) {
         // !null is true, so this should work always
-        isAscending.value[key] = !isAscending.value[key]
+        isAscending.value[key] = !isAscending.value[key];
       }
-      sortBy.value = key
-      await fetchTable()
+      sortBy.value = key;
+      await fetchTable();
     }
 
     onMounted(async () => {
-      await fetchTable()
-    })
+      await fetchTable();
+    });
 
     return {
       facilities,
@@ -158,7 +158,7 @@ export default defineComponent({
       isAscending,
       sortBy,
       toggleSort,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -18,12 +18,12 @@ or an array of values when multiple instances are v-model'd onto the same array.
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   model: {
-    prop: 'checked',
-    event: 'change',
+    prop: "checked",
+    event: "change",
   },
   props: {
     label: {
@@ -50,11 +50,11 @@ export default defineComponent({
     const proxyChecked = computed({
       get: () => props.checked,
       set: (value) => {
-        emit('change', value)
+        emit("change", value);
       },
-    })
+    });
 
-    return { proxyChecked }
+    return { proxyChecked };
   },
-})
+});
 </script>

--- a/components/form/TextArea.vue
+++ b/components/form/TextArea.vue
@@ -15,12 +15,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
     value: {
-      default: '',
+      default: "",
       type: String,
     },
     maxLength: {
@@ -29,5 +29,5 @@ export default defineComponent({
       required: false,
     },
   },
-})
+});
 </script>

--- a/components/form/TextBox.vue
+++ b/components/form/TextBox.vue
@@ -1,19 +1,19 @@
 <template>
   <input
     ref="textBoxRef"
-    class="focus:outline-none block rounded-md border border-gray-300 bg-white py-2 placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500"
+    class="block rounded-md border border-gray-300 bg-white py-2 placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500"
     :value="value"
     @input="$emit('input', $event.target.value)"
   />
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
     value: {
-      default: '',
+      default: "",
       type: String,
     },
     focus: {
@@ -23,15 +23,15 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const textBoxRef = ref<HTMLFormElement>()
+    const textBoxRef = ref<HTMLFormElement>();
 
     onMounted(() => {
       if (props.focus) {
-        textBoxRef.value?.focus()
+        textBoxRef.value?.focus();
       }
-    })
+    });
 
-    return { textBoxRef }
+    return { textBoxRef };
   },
-})
+});
 </script>

--- a/components/form/TextBoxMini.vue
+++ b/components/form/TextBoxMini.vue
@@ -5,21 +5,21 @@ E.g. used in the Filter by Patient Number component in Data Files
 
 <template>
   <input
-    class="focus:outline-none block h-8 rounded-md border border-gray-300 bg-white px-2 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500"
+    class="block h-8 rounded-md border border-gray-300 bg-white px-2 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500"
     :value="value"
     @input="$emit('input', $event.target.value)"
   />
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
     value: {
-      default: '',
+      default: "",
       type: String,
     },
   },
-})
+});
 </script>

--- a/components/generic/Attachment.vue
+++ b/components/generic/Attachment.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -23,5 +23,5 @@ export default defineComponent({
     },
   },
   setup() {},
-})
+});
 </script>

--- a/components/generic/Blackout.vue
+++ b/components/generic/Blackout.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -23,5 +23,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/generic/Button.vue
+++ b/components/generic/Button.vue
@@ -35,7 +35,7 @@ export default {
     colour: {
       type: String,
       required: false,
-      default: 'white',
+      default: "white",
     },
     tooltip: {
       type: String,
@@ -58,7 +58,7 @@ export default {
       default: false,
     },
   },
-}
+};
 </script>
 
 <style lang="postcss">
@@ -99,6 +99,6 @@ export default {
   @apply btn-base-primary bg-white hover:bg-gray-50;
 }
 .btn-base-primary {
-  @apply focus:outline-none rounded-md border py-2 px-4 font-medium shadow-sm focus:ring-2 focus:ring-offset-2;
+  @apply rounded-md border py-2 px-4 font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2;
 }
 </style>

--- a/components/generic/CodeReader.vue
+++ b/components/generic/CodeReader.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref } from "@nuxtjs/composition-api";
 
-import formatXml from 'xml-formatter'
+import formatXml from "xml-formatter";
 
 export default defineComponent({
   props: {
@@ -29,26 +29,26 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const formatMessage = ref(true)
+    const formatMessage = ref(true);
     const formattedMessage = computed(() => {
-      return formatMessageToXML(props.content)
-    })
+      return formatMessageToXML(props.content);
+    });
 
     function formatMessageToXML(content: string): string {
       if (content === null) {
-        return ''
+        return "";
       }
       if (!formatMessage.value) {
-        return content
+        return content;
       } else {
-        return formatXml(content)
+        return formatXml(content);
       }
     }
 
     return {
       formatMessage,
       formattedMessage,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/generic/CollapseHeader.vue
+++ b/components/generic/CollapseHeader.vue
@@ -24,12 +24,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from '@nuxtjs/composition-api'
+import { defineComponent, ref } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   model: {
-    prop: 'open',
-    event: 'change',
+    prop: "open",
+    event: "change",
   },
   props: {
     label: {
@@ -38,16 +38,16 @@ export default defineComponent({
     },
   },
   setup() {
-    const isOpen = ref(false)
+    const isOpen = ref(false);
 
     function toggle(): void {
-      isOpen.value = !isOpen.value
+      isOpen.value = !isOpen.value;
     }
 
     return {
       isOpen,
       toggle,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/generic/DateRange.vue
+++ b/components/generic/DateRange.vue
@@ -74,9 +74,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from '@nuxtjs/composition-api'
+import { defineComponent, ref, computed } from "@nuxtjs/composition-api";
 
-import { DateRange, nowString } from '@/helpers/utils/dateUtils'
+import { DateRange, nowString } from "@/helpers/utils/dateUtils";
 
 export default defineComponent({
   props: {
@@ -89,46 +89,46 @@ export default defineComponent({
       required: false,
       default: () => ({
         start: {
-          type: 'string',
-          mask: 'iso',
+          type: "string",
+          mask: "iso",
         },
         end: {
-          type: 'string',
-          mask: 'iso',
+          type: "string",
+          mask: "iso",
         },
       }),
     },
   },
   setup(props, { emit }) {
-    const showCustom = ref(false)
+    const showCustom = ref(false);
 
     const textBoxClasses =
-      'flex-grow pl-8 pr-2 py-1 w-full h-full bg-white border border-gray-300 rounded-md placeholder-gray-500 focus:outline-none focus:text-gray-900 focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 truncate'
+      "flex-grow pl-8 pr-2 py-1 w-full h-full bg-white border border-gray-300 rounded-md placeholder-gray-500 focus:outline-none focus:text-gray-900 focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 truncate";
 
     function clear(): void {
-      showCustom.value = false
-      emit('input', { start: null, end: null })
+      showCustom.value = false;
+      emit("input", { start: null, end: null });
     }
 
     const lastNDays = computed((): number | null => {
       if (showCustom.value) {
-        return null
+        return null;
       }
       if (props.value.start && props.value.end) {
-        return Math.round((Date.parse(props.value.end) - Date.parse(props.value.start)) / (1000 * 3600 * 24))
+        return Math.round((Date.parse(props.value.end) - Date.parse(props.value.start)) / (1000 * 3600 * 24));
       }
-      return null
-    })
+      return null;
+    });
 
     function setLastNDays(daysAgo: number): void {
-      showCustom.value = false
-      const newRange: DateRange = { start: nowString(-daysAgo), end: nowString(0) }
-      emit('input', newRange)
+      showCustom.value = false;
+      const newRange: DateRange = { start: nowString(-daysAgo), end: nowString(0) };
+      emit("input", newRange);
     }
 
-    return { showCustom, textBoxClasses, lastNDays, setLastNDays, clear }
+    return { showCustom, textBoxClasses, lastNDays, setLastNDays, clear };
   },
-})
+});
 </script>
 
 <style scoped>

--- a/components/generic/Dl.vue
+++ b/components/generic/Dl.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -18,5 +18,5 @@ export default defineComponent({
     },
   },
   setup() {},
-})
+});
 </script>

--- a/components/generic/InfoIcon.vue
+++ b/components/generic/InfoIcon.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   setup() {},
-})
+});
 </script>

--- a/components/generic/ItemPaginator.vue
+++ b/components/generic/ItemPaginator.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -43,22 +43,22 @@ export default defineComponent({
     itemLabel: {
       type: String,
       required: false,
-      default: 'Item',
+      default: "Item",
     },
   },
 
   setup(props, { emit }) {
     function next(): void {
-      emit('input', props.value + 1)
+      emit("input", props.value + 1);
     }
 
     function prev(): void {
-      emit('input', props.value - 1)
+      emit("input", props.value - 1);
     }
 
-    return { next, prev }
+    return { next, prev };
   },
-})
+});
 </script>
 
 <style></style>

--- a/components/generic/Menu.vue
+++ b/components/generic/Menu.vue
@@ -9,7 +9,7 @@
   >
     <div
       v-show="show"
-      class="focus:outline-none absolute w-56 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5"
+      class="absolute w-56 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
       role="menu"
       aria-orientation="vertical"
       aria-labelledby="option-menu-button"
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -33,5 +33,5 @@ export default defineComponent({
       default: false,
     },
   },
-})
+});
 </script>

--- a/components/generic/MenuItem.vue
+++ b/components/generic/MenuItem.vue
@@ -29,12 +29,12 @@
     role="menuitem"
     :tabindex="disabled ? -1 : 0"
     @click="
-      $emit('click')
-      $emit('close')
+      $emit('click');
+      $emit('close');
     "
     @keydown.enter.prevent="
-      $emit('click')
-      $emit('close')
+      $emit('click');
+      $emit('close');
     "
   >
     <slot />
@@ -42,7 +42,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -71,22 +71,22 @@ export default defineComponent({
   setup(props) {
     const classes = computed(() => {
       if (props.disabled) {
-        return ['text-gray-400']
+        return ["text-gray-400"];
       } else {
         return [
-          'text-gray-700',
-          'hover:bg-gray-100',
-          'hover:text-gray-900',
-          'focus:bg-indigo-100',
-          'focus:text-gray-900',
-          'cursor-pointer',
-        ]
+          "text-gray-700",
+          "hover:bg-gray-100",
+          "hover:text-gray-900",
+          "focus:bg-indigo-100",
+          "focus:text-gray-900",
+          "cursor-pointer",
+        ];
       }
-    })
+    });
 
-    return { classes }
+    return { classes };
   },
-})
+});
 </script>
 
 <style lang="postcss">

--- a/components/generic/Paginator.vue
+++ b/components/generic/Paginator.vue
@@ -32,9 +32,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
-type Pages = (number | '...')[]
+type Pages = (number | "...")[];
 
 export default defineComponent({
   props: {
@@ -53,7 +53,7 @@ export default defineComponent({
     scrollTag: {
       type: String,
       required: false,
-      default: 'main',
+      default: "main",
     },
     jumpToTop: {
       type: Boolean,
@@ -70,52 +70,52 @@ export default defineComponent({
   setup(props, { emit }) {
     function pagination(current: number, total: number): Pages {
       if (total <= 1) {
-        return []
+        return [];
       }
-      const center: Pages = [current - 2, current - 1, current, current + 1, current + 2]
-      const filteredCenter = center.filter((p) => p > 1 && p < total)
+      const center: Pages = [current - 2, current - 1, current, current + 1, current + 2];
+      const filteredCenter = center.filter((p) => p > 1 && p < total);
 
-      const includeThreeLeft = current === 5
-      const includeThreeRight = current === total - 4
+      const includeThreeLeft = current === 5;
+      const includeThreeRight = current === total - 4;
 
-      const includeLeftDots = current > 5
-      const includeRightDots = current < total - 4
+      const includeLeftDots = current > 5;
+      const includeRightDots = current < total - 4;
 
-      if (includeThreeLeft) filteredCenter.unshift(2)
-      if (includeThreeRight) filteredCenter.push(total - 1)
+      if (includeThreeLeft) filteredCenter.unshift(2);
+      if (includeThreeRight) filteredCenter.push(total - 1);
 
-      if (includeLeftDots) filteredCenter.unshift('...')
-      if (includeRightDots) filteredCenter.push('...')
+      if (includeLeftDots) filteredCenter.unshift("...");
+      if (includeRightDots) filteredCenter.push("...");
 
-      return [1, ...filteredCenter, total]
+      return [1, ...filteredCenter, total];
     }
 
     const paginationElements = computed(() => {
-      return pagination(props.page, Math.ceil(props.total / props.size))
-    })
+      return pagination(props.page, Math.ceil(props.total / props.size));
+    });
 
     function next(): void {
-      emit('next')
-      toTop()
+      emit("next");
+      toTop();
     }
 
     function prev(): void {
-      emit('prev')
-      toTop()
+      emit("prev");
+      toTop();
     }
 
     function jump(page: number): void {
-      emit('jump', page)
-      toTop()
+      emit("jump", page);
+      toTop();
     }
 
     function toTop(): void {
       if (props.jumpToTop) {
-        document.getElementsByTagName(props.scrollTag)[0].scrollTop = 0
+        document.getElementsByTagName(props.scrollTag)[0].scrollTop = 0;
       }
     }
 
-    const currentPageClasses = ['bg-indigo-500', 'text-white']
+    const currentPageClasses = ["bg-indigo-500", "text-white"];
 
     return {
       next,
@@ -123,9 +123,9 @@ export default defineComponent({
       jump,
       paginationElements,
       currentPageClasses,
-    }
+    };
   },
-})
+});
 </script>
 
 <style></style>

--- a/components/generic/SearchableSelect.vue
+++ b/components/generic/SearchableSelect.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, onMounted, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, nextTick, onMounted, ref } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -110,7 +110,7 @@ export default defineComponent({
     hint: {
       type: String,
       required: false,
-      default: 'Select an item...',
+      default: "Select an item...",
     },
     mountOpened: {
       type: Boolean,
@@ -125,90 +125,90 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
-    const search = ref('')
-    const isOpen = ref(false)
-    const highlightedIndex = ref(0)
+    const search = ref("");
+    const isOpen = ref(false);
+    const highlightedIndex = ref(0);
 
-    const searchInput = ref()
-    const mainInput = ref()
-    const optionElement = ref()
+    const searchInput = ref();
+    const mainInput = ref();
+    const optionElement = ref();
 
     const filteredOptions = computed(() => {
       if (!props.labels) {
-        return props.options.filter((option) => option.toLowerCase().startsWith(search.value.toLowerCase()))
+        return props.options.filter((option) => option.toLowerCase().startsWith(search.value.toLowerCase()));
       }
       return props.options.filter(
         (option, index) =>
           option.toLowerCase().startsWith(search.value.toLowerCase()) ||
           props.labels[index]?.toLowerCase().startsWith(search.value.toLowerCase())
-      )
-    })
+      );
+    });
 
     function open() {
-      isOpen.value = true
+      isOpen.value = true;
       nextTick(() => {
-        searchInput.value.focus()
-      })
+        searchInput.value.focus();
+      });
     }
 
     function close() {
       if (props.closable) {
-        isOpen.value = false
+        isOpen.value = false;
         nextTick(() => {
-          mainInput.value.focus()
-        })
+          mainInput.value.focus();
+        });
       }
     }
 
     function cancel() {
-      close()
+      close();
     }
 
     function commitSelection() {
-      close()
-      emit('input', filteredOptions.value[highlightedIndex.value])
+      close();
+      emit("input", filteredOptions.value[highlightedIndex.value]);
     }
 
     function select(index: number) {
-      highlightedIndex.value = index
-      commitSelection()
+      highlightedIndex.value = index;
+      commitSelection();
     }
 
     function clear() {
-      highlightedIndex.value = 0
-      emit('input', null)
-      close()
+      highlightedIndex.value = 0;
+      emit("input", null);
+      close();
     }
 
     function highlight(index: number) {
-      open()
-      highlightedIndex.value = index
-      optionElement.value[index].scrollIntoView({ block: 'nearest' })
+      open();
+      highlightedIndex.value = index;
+      optionElement.value[index].scrollIntoView({ block: "nearest" });
     }
 
     function highlightPrev() {
-      highlight(highlightedIndex.value - 1 < 0 ? filteredOptions.value.length - 1 : highlightedIndex.value - 1)
+      highlight(highlightedIndex.value - 1 < 0 ? filteredOptions.value.length - 1 : highlightedIndex.value - 1);
     }
 
     function highlightNext() {
-      highlight(highlightedIndex.value + 1 >= filteredOptions.value.length ? 0 : highlightedIndex.value + 1)
+      highlight(highlightedIndex.value + 1 >= filteredOptions.value.length ? 0 : highlightedIndex.value + 1);
     }
 
     function labelFor(value: string): string | null {
       if (props.labels) {
-        const index = props.options.indexOf(value)
+        const index = props.options.indexOf(value);
         if (index) {
-          return props.labels[index]
+          return props.labels[index];
         }
       }
-      return null
+      return null;
     }
 
     onMounted(() => {
       if (props.mountOpened) {
-        open()
+        open();
       }
-    })
+    });
 
     return {
       searchInput,
@@ -227,7 +227,7 @@ export default defineComponent({
       clear,
       commitSelection,
       labelFor,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/generic/Select.vue
+++ b/components/generic/Select.vue
@@ -16,5 +16,5 @@ export default {
       required: true,
     },
   },
-}
+};
 </script>

--- a/components/generic/TabToggle.vue
+++ b/components/generic/TabToggle.vue
@@ -3,7 +3,7 @@
     <nav class="group grid grid-cols-2 rounded-lg bg-gray-100 text-sm font-medium hover:bg-gray-200" aria-label="Tabs">
       <!-- Current: "text-gray-900", Default: "text-gray-500 hover:text-gray-700" -->
       <button
-        class="focus:outline-none truncate rounded-md focus:ring-offset-gray-100"
+        class="truncate rounded-md focus:outline-none focus:ring-offset-gray-100"
         :class="!value ? 'tab-active' : 'tab-inactive'"
         @click="$emit('input', false)"
       >
@@ -11,7 +11,7 @@
       </button>
 
       <button
-        class="focus:outline-none truncate rounded-md focus:ring-offset-gray-100"
+        class="truncate rounded-md focus:outline-none focus:ring-offset-gray-100"
         :class="value ? 'tab-active' : 'tab-inactive'"
         @click="$emit('input', true)"
       >
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -40,9 +40,9 @@ export default defineComponent({
     },
   },
   setup() {
-    return {}
+    return {};
   },
-})
+});
 </script>
 
 <style lang="postcss">

--- a/components/generic/Toast.vue
+++ b/components/generic/Toast.vue
@@ -33,7 +33,7 @@
               </div>
               <div class="ml-4 flex flex-shrink-0">
                 <button
-                  class="focus:outline-none inline-flex text-gray-400 transition duration-150 ease-in-out focus:text-gray-500"
+                  class="inline-flex text-gray-400 transition duration-150 ease-in-out focus:text-gray-500 focus:outline-none"
                   @click="destroy"
                 >
                   <svg
@@ -78,7 +78,7 @@
             <div class="-ml-px flex flex-col">
               <div class="flex h-0 flex-1 border-b border-gray-200">
                 <button
-                  class="focus:outline-none focus:shadow-outline-blue -mb-px flex w-full items-center justify-center rounded-tr-lg border border-transparent px-4 py-3 font-medium leading-5 text-indigo-600 transition duration-150 ease-in-out hover:text-indigo-500 focus:border-blue-300 active:bg-gray-50 active:text-indigo-700"
+                  class="focus:shadow-outline-blue -mb-px flex w-full items-center justify-center rounded-tr-lg border border-transparent px-4 py-3 font-medium leading-5 text-indigo-600 transition duration-150 ease-in-out hover:text-indigo-500 focus:border-blue-300 focus:outline-none active:bg-gray-50 active:text-indigo-700"
                   @click="primaryAction"
                 >
                   {{ primary.label }}
@@ -86,7 +86,7 @@
               </div>
               <div class="-mt-px flex h-0 flex-1">
                 <button
-                  class="focus:outline-none focus:shadow-outline-blue flex w-full items-center justify-center rounded-br-lg border border-transparent px-4 py-3 font-medium leading-5 text-gray-700 transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 active:bg-gray-50 active:text-gray-800"
+                  class="focus:shadow-outline-blue flex w-full items-center justify-center rounded-br-lg border border-transparent px-4 py-3 font-medium leading-5 text-gray-700 transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 focus:outline-none active:bg-gray-50 active:text-gray-800"
                   @click="secondaryAction"
                 >
                   {{ secondary.label }}
@@ -113,7 +113,7 @@
               <div class="flex w-0 flex-1 justify-between">
                 <p class="w-0 flex-1 leading-5">{{ message }}</p>
                 <button
-                  class="focus:outline-none ml-3 flex-shrink-0 font-medium leading-5 text-indigo-600 transition duration-150 ease-in-out hover:text-indigo-500 focus:underline"
+                  class="ml-3 flex-shrink-0 font-medium leading-5 text-indigo-600 transition duration-150 ease-in-out hover:text-indigo-500 focus:underline focus:outline-none"
                   @click="primaryAction"
                 >
                   {{ primary.label }}
@@ -121,7 +121,7 @@
               </div>
               <div class="ml-4 flex flex-shrink-0">
                 <button
-                  class="focus:outline-none inline-flex text-gray-400 transition duration-150 ease-in-out focus:text-gray-500"
+                  class="inline-flex text-gray-400 transition duration-150 ease-in-out focus:text-gray-500 focus:outline-none"
                   @click="destroy"
                 >
                   <svg
@@ -145,11 +145,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
-import { removeElement } from '@/helpers/utils/domUtils'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
+import { removeElement } from "@/helpers/utils/domUtils";
 
 interface Action {
-  action(): void
+  action(): void;
 }
 
 export default defineComponent({
@@ -162,15 +162,15 @@ export default defineComponent({
     message: {
       type: String,
       required: false,
-      default: 'Please specify a <b>message</b>',
+      default: "Please specify a <b>message</b>",
     },
     type: {
       type: String,
       required: false,
       validate: (type: string) => {
-        return ['success', 'info', 'danger', 'warning', 'denied'].includes(type)
+        return ["success", "info", "danger", "warning", "denied"].includes(type);
       },
-      default: '',
+      default: "",
     },
     progress: {
       type: Boolean,
@@ -200,27 +200,27 @@ export default defineComponent({
     classToast: {
       type: String,
       required: false,
-      default: 'bg-white border border-gray-300',
+      default: "bg-white border border-gray-300",
     },
     classTitle: {
       type: String,
       required: false,
-      default: 'text-gray-900',
+      default: "text-gray-900",
     },
     classMessage: {
       type: String,
       required: false,
-      default: 'text-gray-500',
+      default: "text-gray-500",
     },
     classClose: {
       type: String,
       required: false,
-      default: 'text-gray-400',
+      default: "text-gray-400",
     },
     classTimeout: {
       type: String,
       required: false,
-      default: 'bg-gray-200',
+      default: "bg-gray-200",
     },
     defaults: {
       type: Object,
@@ -230,65 +230,65 @@ export default defineComponent({
   },
 
   setup(props) {
-    const toastRootElement = ref()
+    const toastRootElement = ref();
 
-    const active = ref(false)
-    const interval = ref()
-    const timeLeft = ref()
-    const speed = ref(100)
+    const active = ref(false);
+    const interval = ref();
+    const timeLeft = ref();
+    const speed = ref(100);
 
     const classToastAll = computed(() => {
       if (props.defaults && props.defaults.classToast) {
-        return [props.classToast, props.defaults.classToast]
+        return [props.classToast, props.defaults.classToast];
       }
-      if (props.classToast) return [props.classToast]
-      return []
-    })
+      if (props.classToast) return [props.classToast];
+      return [];
+    });
 
     const timeLeftPercent = computed(() => {
       if (!props.timeout) {
-        return 0
+        return 0;
       }
-      return Math.round((((timeLeft.value * 100) / (props.timeout * 1000)) * 100) / 100)
-    })
+      return Math.round((((timeLeft.value * 100) / (props.timeout * 1000)) * 100) / 100);
+    });
 
     const progressStyle = computed(() => {
-      return `width: ${timeLeftPercent.value}%; transition: width 0.1s linear;`
-    })
+      return `width: ${timeLeftPercent.value}%; transition: width 0.1s linear;`;
+    });
 
     function updateTime() {
-      timeLeft.value -= speed.value
+      timeLeft.value -= speed.value;
       if (timeLeft.value === 0) {
-        destroy()
+        destroy();
       }
     }
 
     function destroy() {
-      active.value = false
-      clearInterval(interval.value)
+      active.value = false;
+      clearInterval(interval.value);
       setTimeout(() => {
-        destroy()
-        removeElement(toastRootElement.value)
-      }, 1000)
+        destroy();
+        removeElement(toastRootElement.value);
+      }, 1000);
     }
 
     function primaryAction() {
-      props.primary.action()
-      destroy()
+      props.primary.action();
+      destroy();
     }
 
     function secondaryAction() {
-      props.secondary.action()
-      destroy()
+      props.secondary.action();
+      destroy();
     }
 
     onMounted(() => {
-      active.value = true
+      active.value = true;
       if (props.timeout > 0) {
-        timeLeft.value = props.timeout * 1000
-        interval.value = setInterval(() => updateTime(), speed.value)
+        timeLeft.value = props.timeout * 1000;
+        interval.value = setInterval(() => updateTime(), speed.value);
       }
-    })
+    });
 
     return {
       toastRootElement,
@@ -302,7 +302,7 @@ export default defineComponent({
       destroy,
       primaryAction,
       secondaryAction,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/generic/Toggle.vue
+++ b/components/generic/Toggle.vue
@@ -3,7 +3,7 @@
     <!-- Enabled: "bg-indigo-600", Not Enabled: "bg-gray-200" -->
     <button
       type="button"
-      class="focus:outline-none relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
       :class="{ 'bg-green-400': value }"
       aria-pressed="false"
       aria-labelledby="toggle-label"
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -40,10 +40,10 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     function toggle() {
-      emit('input', !props.value)
+      emit("input", !props.value);
     }
 
-    return { toggle }
+    return { toggle };
   },
-})
+});
 </script>

--- a/components/generic/alert/Error.vue
+++ b/components/generic/alert/Error.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -34,5 +34,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/generic/alert/Info.vue
+++ b/components/generic/alert/Info.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -34,5 +34,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/generic/alert/Warning.vue
+++ b/components/generic/alert/Warning.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -34,5 +34,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/generic/button/Close.vue
+++ b/components/generic/button/Close.vue
@@ -2,7 +2,7 @@
   <div class="flex gap-2">
     <button
       type="button"
-      class="focus:outline-none flex items-start gap-1 rounded-full border border-gray-300 bg-white px-2 py-1 text-gray-500 shadow-sm hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      class="flex items-start gap-1 rounded-full border border-gray-300 bg-white px-2 py-1 text-gray-500 shadow-sm hover:bg-gray-50 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
       @click="$emit('click')"
     >
       <TextL1>Close</TextL1>

--- a/components/generic/button/Mini.vue
+++ b/components/generic/button/Mini.vue
@@ -36,7 +36,7 @@
   </button>
 </template>
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -48,7 +48,7 @@ export default defineComponent({
     colour: {
       type: String,
       required: false,
-      default: 'white',
+      default: "white",
     },
     tooltip: {
       type: String,
@@ -71,7 +71,7 @@ export default defineComponent({
       default: null,
     },
   },
-})
+});
 </script>
 
 <style lang="postcss">
@@ -101,12 +101,12 @@ export default defineComponent({
 }
 .btn-mini-base {
   min-height: 2rem;
-  @apply focus:outline-none
-      items-center
+  @apply items-center
       px-2
       py-1
       text-sm
       font-medium
-      shadow-sm focus:ring-1;
+      shadow-sm
+      focus:outline-none focus:ring-1;
 }
 </style>

--- a/components/generic/button/Raw.vue
+++ b/components/generic/button/Raw.vue
@@ -9,7 +9,7 @@
   </button>
 </template>
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -24,5 +24,5 @@ export default defineComponent({
       default: null,
     },
   },
-})
+});
 </script>

--- a/components/generic/button/Round.vue
+++ b/components/generic/button/Round.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -43,21 +43,21 @@ export default defineComponent({
       default: null,
     },
   },
-})
+});
 </script>
 
 <style lang="postcss">
 .btn-round-base {
-  @apply focus:outline-none
-      inline-flex
+  @apply inline-flex
       items-center
-      rounded-full border
-      border-gray-300
+      rounded-full
+      border border-gray-300
       bg-white
       p-1
       text-gray-400
       shadow-sm
       hover:bg-gray-50
-      hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2;
+      hover:text-gray-500
+      focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2;
 }
 </style>

--- a/components/generic/card/Flat.vue
+++ b/components/generic/card/Flat.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-export default {}
+export default {};
 </script>
 
 <style></style>

--- a/components/generic/card/Mini.vue
+++ b/components/generic/card/Mini.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-export default {}
+export default {};
 </script>
 
 <style></style>

--- a/components/generic/modal/Confirm.vue
+++ b/components/generic/modal/Confirm.vue
@@ -41,8 +41,8 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
-import { modalInterface } from '~/interfaces/modal'
+import { computed, defineComponent, ref } from "@nuxtjs/composition-api";
+import { modalInterface } from "~/interfaces/modal";
 
 export default defineComponent({
   props: {
@@ -57,12 +57,12 @@ export default defineComponent({
     confirmLabel: {
       type: String,
       required: false,
-      default: 'Confirm',
+      default: "Confirm",
     },
     cancelLabel: {
       type: String,
       required: false,
-      default: 'Cancel',
+      default: "Cancel",
     },
     danger: {
       type: Boolean,
@@ -77,41 +77,41 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
-    const confirmModal = ref<modalInterface>()
+    const confirmModal = ref<modalInterface>();
 
     const visible = computed(() => {
-      return confirmModal.value?.visible || false
-    })
+      return confirmModal.value?.visible || false;
+    });
 
     function show(): void {
-      return confirmModal.value?.show()
+      return confirmModal.value?.show();
     }
 
     function hide(): void {
-      return confirmModal.value?.hide()
+      return confirmModal.value?.hide();
     }
 
     function toggle(): void {
-      return confirmModal.value?.toggle()
+      return confirmModal.value?.toggle();
     }
 
     const modalIcon = computed(() => {
       if (props.icon !== null) {
-        return props.icon
+        return props.icon;
       } else if (props.danger) {
-        return 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
+        return "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z";
       } else {
-        return 'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+        return "M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z";
       }
-    })
+    });
 
     function confirm(): void {
-      emit('confirm')
-      hide()
+      emit("confirm");
+      hide();
     }
     function cancel(): void {
-      emit('cancel')
-      hide()
+      emit("cancel");
+      hide();
     }
 
     return {
@@ -123,7 +123,7 @@ export default defineComponent({
       show,
       hide,
       toggle,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/generic/modal/Slot.vue
+++ b/components/generic/modal/Slot.vue
@@ -26,19 +26,19 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import useModal from '@/helpers/useModal'
+import { defineComponent } from "@nuxtjs/composition-api";
+import useModal from "@/helpers/useModal";
 
 export default defineComponent({
   setup() {
-    const { visible, show, hide, toggle } = useModal()
+    const { visible, show, hide, toggle } = useModal();
 
     return {
       visible,
       show,
       hide,
       toggle,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/generic/tabs/Line.vue
+++ b/components/generic/tabs/Line.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -51,5 +51,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/generic/tabs/Mini.vue
+++ b/components/generic/tabs/Mini.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -45,5 +45,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/generic/tabs/Navigation.vue
+++ b/components/generic/tabs/Navigation.vue
@@ -41,12 +41,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useRouter } from '@nuxtjs/composition-api'
-import { urlCompare } from '@/helpers/utils/pathUtils'
+import { defineComponent, useRouter } from "@nuxtjs/composition-api";
+import { urlCompare } from "@/helpers/utils/pathUtils";
 
 export interface Tabs {
-  name: string
-  href: string
+  name: string;
+  href: string;
 }
 
 export default defineComponent({
@@ -57,13 +57,13 @@ export default defineComponent({
     },
   },
   setup(_, { emit }) {
-    const router = useRouter()
+    const router = useRouter();
 
     function switchTab(href: string) {
-      router.push({ path: href })
-      emit('input', href)
+      router.push({ path: href });
+      emit("input", href);
     }
-    return { urlCompare, switchTab }
+    return { urlCompare, switchTab };
   },
-})
+});
 </script>

--- a/components/icon/dynamic/Filter.vue
+++ b/components/icon/dynamic/Filter.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -15,5 +15,5 @@ export default defineComponent({
       default: true,
     },
   },
-})
+});
 </script>

--- a/components/icon/dynamic/Sort.vue
+++ b/components/icon/dynamic/Sort.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -21,5 +21,5 @@ export default defineComponent({
       default: true,
     },
   },
-})
+});
 </script>

--- a/components/link/PostCode.vue
+++ b/components/link/PostCode.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -21,14 +21,14 @@ export default defineComponent({
   },
   setup(props) {
     const urlQuery = computed(() => {
-      const { code } = props
+      const { code } = props;
       if (code) {
-        return `q=${encodeURIComponent(code)}`
+        return `q=${encodeURIComponent(code)}`;
       }
-      return ''
-    })
+      return "";
+    });
 
-    return { urlQuery }
+    return { urlQuery };
   },
-})
+});
 </script>

--- a/components/link/SendingFacility.vue
+++ b/components/link/SendingFacility.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -18,5 +18,5 @@ export default defineComponent({
       default: null,
     },
   },
-})
+});
 </script>

--- a/components/masterrecords/LinkRecord.vue
+++ b/components/masterrecords/LinkRecord.vue
@@ -38,15 +38,15 @@ Includes a header with the Link Record ID and functionality to Unlink the record
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, useContext, useRouter } from '@nuxtjs/composition-api'
+import { defineComponent, ref, useContext, useRouter } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
 
-import fetchEMPI from '~/helpers/fetch/fetchEMPI'
+import fetchEMPI from "~/helpers/fetch/fetchEMPI";
 
-import { LinkRecord } from '@/interfaces/linkrecords'
-import { modalInterface } from '~/interfaces/modal'
+import { LinkRecord } from "@/interfaces/linkrecords";
+import { modalInterface } from "~/interfaces/modal";
 
 export default defineComponent({
   props: {
@@ -56,28 +56,28 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const router = useRouter()
-    const { $toast } = useContext()
-    const { PostEMPIUnlink } = fetchEMPI()
+    const router = useRouter();
+    const { $toast } = useContext();
+    const { PostEMPIUnlink } = fetchEMPI();
 
-    const unlinkModal = ref<modalInterface>()
-    const unlinkComment = ref('')
+    const unlinkModal = ref<modalInterface>();
+    const unlinkComment = ref("");
 
     function doUnlink() {
       PostEMPIUnlink(props.record.person.id, props.record.masterRecord.id, unlinkComment.value)
         .then((response: LinkRecord) => {
           $toast.show({
-            type: 'success',
-            title: 'Success',
-            message: 'Record unlink request sent successfully',
+            type: "success",
+            title: "Success",
+            message: "Record unlink request sent successfully",
             timeout: 10,
-            classTimeout: 'bg-green-600',
-          })
-          router.push({ path: `/masterrecords/${response.masterRecord.id}` })
+            classTimeout: "bg-green-600",
+          });
+          router.push({ path: `/masterrecords/${response.masterRecord.id}` });
         })
         .finally(() => {
-          unlinkModal.value?.hide()
-        })
+          unlinkModal.value?.hide();
+        });
     }
 
     return {
@@ -86,9 +86,9 @@ export default defineComponent({
       doUnlink,
       formatGender,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>
 
 <style></style>

--- a/components/masterrecords/ListItem.vue
+++ b/components/masterrecords/ListItem.vue
@@ -36,10 +36,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGenderCharacter } from '@/helpers/utils/codeUtils'
-import { MasterRecord } from '@/interfaces/masterrecord'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGenderCharacter } from "@/helpers/utils/codeUtils";
+import { MasterRecord } from "@/interfaces/masterrecord";
 
 export default defineComponent({
   props: {
@@ -54,7 +54,7 @@ export default defineComponent({
     detailsLabel: {
       type: String,
       required: false,
-      default: 'Details',
+      default: "Details",
     },
     // Override details data value, see above
     detailsValue: {
@@ -66,20 +66,20 @@ export default defineComponent({
 
   setup() {
     function TagClass(nationalidType: string): string[] {
-      if (nationalidType.trim() === 'UKRDC') {
-        return ['bg-red-100', 'text-red-800']
-      } else if (nationalidType.trim() === 'NHS') {
-        return ['bg-blue-100', 'text-blue-800']
-      } else if (nationalidType.trim() === 'CHI') {
-        return ['bg-purple-100', 'text-purple-800']
-      } else if (nationalidType.trim() === 'HSC') {
-        return ['bg-green-100', 'text-green-800']
+      if (nationalidType.trim() === "UKRDC") {
+        return ["bg-red-100", "text-red-800"];
+      } else if (nationalidType.trim() === "NHS") {
+        return ["bg-blue-100", "text-blue-800"];
+      } else if (nationalidType.trim() === "CHI") {
+        return ["bg-purple-100", "text-purple-800"];
+      } else if (nationalidType.trim() === "HSC") {
+        return ["bg-green-100", "text-green-800"];
       } else {
-        return ['bg-gray-100', 'text-gray-800']
+        return ["bg-gray-100", "text-gray-800"];
       }
     }
 
-    return { TagClass, formatDate, formatGenderCharacter }
+    return { TagClass, formatDate, formatGenderCharacter };
   },
-})
+});
 </script>

--- a/components/masterrecords/NationalIdTypeTag.vue
+++ b/components/masterrecords/NationalIdTypeTag.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -20,22 +20,22 @@ export default defineComponent({
 
   setup() {
     function TagClass(nationalidType: string): string[] {
-      if (nationalidType.trim().endsWith('UKRDC')) {
-        return ['bg-red-100', 'text-red-800']
-      } else if (nationalidType.trim().endsWith('NHS')) {
-        return ['bg-blue-100', 'text-blue-800']
-      } else if (nationalidType.trim().endsWith('CHI')) {
-        return ['bg-purple-100', 'text-purple-800']
-      } else if (nationalidType.trim().endsWith('HSC')) {
-        return ['bg-green-100', 'text-green-800']
+      if (nationalidType.trim().endsWith("UKRDC")) {
+        return ["bg-red-100", "text-red-800"];
+      } else if (nationalidType.trim().endsWith("NHS")) {
+        return ["bg-blue-100", "text-blue-800"];
+      } else if (nationalidType.trim().endsWith("CHI")) {
+        return ["bg-purple-100", "text-purple-800"];
+      } else if (nationalidType.trim().endsWith("HSC")) {
+        return ["bg-green-100", "text-green-800"];
       } else {
-        return ['bg-gray-100', 'text-gray-800']
+        return ["bg-gray-100", "text-gray-800"];
       }
     }
 
-    return { TagClass }
+    return { TagClass };
   },
-})
+});
 </script>
 
 <style></style>

--- a/components/masterrecords/RecordCard.vue
+++ b/components/masterrecords/RecordCard.vue
@@ -49,11 +49,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
 
-import { MasterRecord } from '~/interfaces/masterrecord'
+import { MasterRecord } from "~/interfaces/masterrecord";
 
 export default defineComponent({
   props: {
@@ -74,16 +74,16 @@ export default defineComponent({
   },
   setup() {
     const highlightClasses = [
-      'bg-red-100',
-      'text-red-800',
-      'font-medium',
-      'rounded-md',
-      'pl-2',
-      '-ml-2',
-      'pr-2',
-      'mr-2',
-    ]
-    return { highlightClasses, formatDate, formatGender }
+      "bg-red-100",
+      "text-red-800",
+      "font-medium",
+      "rounded-md",
+      "pl-2",
+      "-ml-2",
+      "pr-2",
+      "mr-2",
+    ];
+    return { highlightClasses, formatDate, formatGender };
   },
-})
+});
 </script>

--- a/components/messages/ListItem.vue
+++ b/components/messages/ListItem.vue
@@ -5,10 +5,10 @@
       <div class="col-span-5 lg:col-span-3">
         <div class="truncate">
           <TextL1 class="truncate md:inline">
-            {{ item.filename || 'No filename found' }}
+            {{ item.filename || "No filename found" }}
           </TextL1>
           <TextL1 class="truncate md:inline">
-            {{ item.channel ? `on ${item.channel}` : '' }}
+            {{ item.channel ? `on ${item.channel}` : "" }}
           </TextL1>
         </div>
         <div class="mt-2 flex">
@@ -39,7 +39,7 @@
         <div class="flex-grow">
           <TextL1>Patient Number</TextL1>
           <TextP class="mt-2">
-            {{ item.ni || 'None Found' }}
+            {{ item.ni || "None Found" }}
           </TextP>
         </div>
       </div>
@@ -48,10 +48,10 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { MessageSummary } from '@/helpers/utils/messageUtils'
-import { Message } from '@/interfaces/messages'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { MessageSummary } from "@/helpers/utils/messageUtils";
+import { Message } from "@/interfaces/messages";
 
 export default defineComponent({
   props: {
@@ -67,9 +67,9 @@ export default defineComponent({
   },
   setup(props) {
     const itemDescription = computed(() => {
-      return MessageSummary(props.item)
-    })
-    return { itemDescription, formatDate }
+      return MessageSummary(props.item);
+    });
+    return { itemDescription, formatDate };
   },
-})
+});
 </script>

--- a/components/messages/StatusBadge.vue
+++ b/components/messages/StatusBadge.vue
@@ -5,8 +5,8 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
-import { Message } from '@/interfaces/messages'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import { Message } from "@/interfaces/messages";
 
 export default defineComponent({
   props: {
@@ -17,14 +17,14 @@ export default defineComponent({
   },
   setup(props) {
     const classes = computed(() => {
-      if (props.message.msgStatus === 'ERROR') {
-        return ['bg-red-100', 'text-red-800']
-      } else if (props.message.msgStatus === 'RECEIVED') {
-        return ['bg-yellow-100', 'text-yellow-800']
+      if (props.message.msgStatus === "ERROR") {
+        return ["bg-red-100", "text-red-800"];
+      } else if (props.message.msgStatus === "RECEIVED") {
+        return ["bg-yellow-100", "text-yellow-800"];
       }
-      return ['bg-green-100', 'text-green-800']
-    })
-    return { classes }
+      return ["bg-green-100", "text-green-800"];
+    });
+    return { classes };
   },
-})
+});
 </script>

--- a/components/mirth/ConnectorMessageCard.vue
+++ b/components/mirth/ConnectorMessageCard.vue
@@ -29,9 +29,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
-import { ConnectorMessage } from '@/interfaces/mirth'
-import { connectorMessageError } from '~/helpers/utils/mirthUtils'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import { ConnectorMessage } from "@/interfaces/mirth";
+import { connectorMessageError } from "~/helpers/utils/mirthUtils";
 
 export default defineComponent({
   props: {
@@ -43,10 +43,10 @@ export default defineComponent({
 
   setup(props) {
     const errorMessage = computed(() => {
-      return connectorMessageError(props.message)
-    })
+      return connectorMessageError(props.message);
+    });
 
-    return { errorMessage }
+    return { errorMessage };
   },
-})
+});
 </script>

--- a/components/mirth/MessageCard.vue
+++ b/components/mirth/MessageCard.vue
@@ -12,8 +12,8 @@
         <GenericDi>
           <TextDt>Processed</TextDt>
           <TextDd v-if="message && !isEmptyObject(message)">
-            {{ message.processed ? 'Yes' : 'No' }}
-            {{ hasErrors ? '(with errors)' : '' }}
+            {{ message.processed ? "Yes" : "No" }}
+            {{ hasErrors ? "(with errors)" : "" }}
           </TextDd>
           <SkeleText v-else class="h-6 w-full" />
         </GenericDi>
@@ -31,12 +31,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
-import { ChannelMessage } from '@/interfaces/mirth'
+import { ChannelMessage } from "@/interfaces/mirth";
 
-import { isEmptyObject } from '@/helpers/utils/objectUtils'
-import { messageHasErrors } from '~/helpers/utils/mirthUtils'
+import { isEmptyObject } from "@/helpers/utils/objectUtils";
+import { messageHasErrors } from "~/helpers/utils/mirthUtils";
 
 export default defineComponent({
   props: {
@@ -48,22 +48,22 @@ export default defineComponent({
   },
   setup(props) {
     const channelName = computed(() => {
-      let name: string = ''
+      let name: string = "";
       for (const msg of Object.values(props.message.connectorMessages)) {
         if (!name.includes(msg.channelName)) {
-          name = name + '/' + msg.channelName
+          name = name + "/" + msg.channelName;
         }
       }
-      return name.substring(1)
-    })
+      return name.substring(1);
+    });
 
     const hasErrors = computed((): boolean => {
-      return messageHasErrors(props.message)
-    })
+      return messageHasErrors(props.message);
+    });
 
-    return { channelName, hasErrors, isEmptyObject }
+    return { channelName, hasErrors, isEmptyObject };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/components/mirth/MessageChain.vue
+++ b/components/mirth/MessageChain.vue
@@ -20,11 +20,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
-import { ChainMap, ChannelMessage, ConnectorMessage } from '@/interfaces/mirth'
+import { ChainMap, ChannelMessage, ConnectorMessage } from "@/interfaces/mirth";
 
-import { isEmptyObject } from '@/helpers/utils/objectUtils'
+import { isEmptyObject } from "@/helpers/utils/objectUtils";
 
 export default defineComponent({
   props: {
@@ -35,25 +35,25 @@ export default defineComponent({
   },
   setup(props) {
     const chain = computed(() => {
-      const currentChain = {} as ChainMap
+      const currentChain = {} as ChainMap;
       if (props.message.connectorMessages) {
         for (const msg of Object.values(props.message.connectorMessages)) {
           if (!(msg.chainId in currentChain)) {
-            currentChain[msg.chainId] = []
+            currentChain[msg.chainId] = [];
           }
-          currentChain[msg.chainId].push(msg)
+          currentChain[msg.chainId].push(msg);
         }
         for (const index in currentChain) {
-          currentChain[index].sort((a: ConnectorMessage, b: ConnectorMessage) => (a.orderId > b.orderId ? 1 : -1))
+          currentChain[index].sort((a: ConnectorMessage, b: ConnectorMessage) => (a.orderId > b.orderId ? 1 : -1));
         }
       }
-      return currentChain
-    })
+      return currentChain;
+    });
 
     return {
       chain,
       isEmptyObject,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/mirth/MessageListItem.vue
+++ b/components/mirth/MessageListItem.vue
@@ -12,8 +12,8 @@
           <div class="col-span-1">
             <TextP> {{ connectorMessagesArray.length }} messages in chain</TextP>
             <TextP class="mt-2 line-clamp-2">
-              {{ message.processed ? 'Processed' : 'Failed' }}
-              {{ hasErrors ? ' with errors' : '' }}
+              {{ message.processed ? "Processed" : "Failed" }}
+              {{ hasErrors ? " with errors" : "" }}
             </TextP>
           </div>
         </div>
@@ -26,12 +26,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
-import { ChannelMessage } from '@/interfaces/mirth'
+import { ChannelMessage } from "@/interfaces/mirth";
 
-import { isEmptyObject } from '@/helpers/utils/objectUtils'
-import { messageHasErrors } from '@/helpers/utils/mirthUtils'
+import { isEmptyObject } from "@/helpers/utils/objectUtils";
+import { messageHasErrors } from "@/helpers/utils/mirthUtils";
 
 export default defineComponent({
   props: {
@@ -42,25 +42,25 @@ export default defineComponent({
   },
   setup(props) {
     const connectorMessagesArray = computed(() => {
-      return Object.values(props.message.connectorMessages)
-    })
+      return Object.values(props.message.connectorMessages);
+    });
     const channelName = computed(() => {
-      let name: string = ''
+      let name: string = "";
       for (const msg of connectorMessagesArray.value) {
         if (!name.includes(msg.channelName)) {
-          name = name + '/' + msg.channelName
+          name = name + "/" + msg.channelName;
         }
       }
-      return name.substring(1)
-    })
+      return name.substring(1);
+    });
 
     const hasErrors = computed((): boolean => {
-      return messageHasErrors(props.message)
-    })
+      return messageHasErrors(props.message);
+    });
 
-    return { connectorMessagesArray, channelName, hasErrors, isEmptyObject }
+    return { connectorMessagesArray, channelName, hasErrors, isEmptyObject };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/components/navigation/Sidebar.vue
+++ b/components/navigation/Sidebar.vue
@@ -2,7 +2,7 @@
   <div class="bg-gray-50">
     <div v-if="showCloseButton" class="absolute top-0 right-0 -mr-12 pt-2">
       <button
-        class="focus:outline-none ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:ring-2 focus:ring-inset focus:ring-white"
+        class="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
         @click="$emit('toggle')"
       >
         <span class="sr-only">Close sidebar</span>
@@ -71,14 +71,14 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
-import usePermissions from '~/helpers/usePermissions'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import usePermissions from "~/helpers/usePermissions";
 
 interface NavItem {
-  title: string
-  url: string
-  svg: string
-  visible: boolean
+  title: string;
+  url: string;
+  svg: string;
+  visible: boolean;
 }
 
 export default defineComponent({
@@ -96,79 +96,79 @@ export default defineComponent({
   },
 
   setup() {
-    const { hasPermission, hasMultipleFacilities } = usePermissions()
+    const { hasPermission, hasMultipleFacilities } = usePermissions();
 
     const pages = computed(() => {
       return [
         {
-          title: 'Dashboard',
-          url: '/',
-          svg: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6',
+          title: "Dashboard",
+          url: "/",
+          svg: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6",
           visible: true,
         },
         {
-          title: 'Records',
-          url: '/masterrecords',
-          svg: 'M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4',
-          visible: hasPermission('ukrdc:records:read'),
+          title: "Records",
+          url: "/masterrecords",
+          svg: "M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4",
+          visible: hasPermission("ukrdc:records:read"),
         },
         {
-          title: 'Data Admin',
+          title: "Data Admin",
           visible:
-            hasPermission('ukrdc:workitems:read') ||
-            hasPermission('ukrdc:workitems:write') ||
-            hasPermission('ukrdc:messages:read') ||
-            hasPermission('ukrdc:messages:write'),
+            hasPermission("ukrdc:workitems:read") ||
+            hasPermission("ukrdc:workitems:write") ||
+            hasPermission("ukrdc:messages:read") ||
+            hasPermission("ukrdc:messages:write"),
         },
         {
-          title: 'EMPI',
-          url: '/empi',
-          svg: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
-          visible: hasPermission('ukrdc:empi:write'),
+          title: "EMPI",
+          url: "/empi",
+          svg: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
+          visible: hasPermission("ukrdc:empi:write"),
         },
         {
-          title: 'Work Items',
-          url: '/workitems',
-          svg: 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
-          visible: hasPermission('ukrdc:workitems:read'),
+          title: "Work Items",
+          url: "/workitems",
+          svg: "M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1",
+          visible: hasPermission("ukrdc:workitems:read"),
         },
         {
-          title: 'Data Files',
-          url: '/messages',
-          svg: 'M8 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-2m-4-1v8m0 0l3-3m-3 3L9 8m-5 5h2.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293h3.172a1 1 0 00.707-.293l2.414-2.414a1 1 0 01.707-.293H20',
-          visible: hasPermission('ukrdc:messages:read') || hasPermission('ukrdc:messages:write'),
+          title: "Data Files",
+          url: "/messages",
+          svg: "M8 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-2m-4-1v8m0 0l3-3m-3 3L9 8m-5 5h2.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293h3.172a1 1 0 00.707-.293l2.414-2.414a1 1 0 01.707-.293H20",
+          visible: hasPermission("ukrdc:messages:read") || hasPermission("ukrdc:messages:write"),
         },
         {
-          title: 'System',
+          title: "System",
           visible:
-            hasPermission('ukrdc:mirth:read') ||
-            hasPermission('ukrdc:mirth:write') ||
-            hasPermission('ukrdc:codes:read') ||
-            hasPermission('ukrdc:codes:write') ||
+            hasPermission("ukrdc:mirth:read") ||
+            hasPermission("ukrdc:mirth:write") ||
+            hasPermission("ukrdc:codes:read") ||
+            hasPermission("ukrdc:codes:write") ||
             hasMultipleFacilities.value,
         },
         {
-          title: 'Facilities',
-          url: '/facilities',
-          svg: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4',
+          title: "Facilities",
+          url: "/facilities",
+          svg: "M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4",
           visible: hasMultipleFacilities.value,
         },
         {
-          title: 'Channels',
-          url: '/mirth',
-          svg: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10',
-          visible: hasPermission('ukrdc:mirth:read'),
+          title: "Channels",
+          url: "/mirth",
+          svg: "M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10",
+          visible: hasPermission("ukrdc:mirth:read"),
         },
         {
-          title: 'Codes',
-          url: '/codes',
-          svg: 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
-          visible: hasPermission('ukrdc:codes:read'),
+          title: "Codes",
+          url: "/codes",
+          svg: "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253",
+          visible: hasPermission("ukrdc:codes:read"),
         },
-      ] as NavItem[]
-    })
+      ] as NavItem[];
+    });
 
-    return { pages }
+    return { pages };
   },
-})
+});
 </script>

--- a/components/patientrecords/DeleteModal.vue
+++ b/components/patientrecords/DeleteModal.vue
@@ -39,7 +39,7 @@
               </div>
               <div class="mt-3 ml-8 text-left sm:mt-0 sm:ml-4">
                 <h3 id="modal-headline" class="text-lg font-medium leading-6 text-gray-900">
-                  {{ previewErrorMessage ? 'Unable to delete patient record' : 'Delete patient record' }}
+                  {{ previewErrorMessage ? "Unable to delete patient record" : "Delete patient record" }}
                 </h3>
                 <div class="mt-2 mb-4">
                   <div v-if="previewErrorMessage">
@@ -201,30 +201,30 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, useContext, watch } from '@nuxtjs/composition-api'
-import useModal from '@/helpers/useModal'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { PatientRecord, PatientRecordFull } from '~/interfaces/patientrecord'
-import { MasterRecord } from '~/interfaces/masterrecord'
-import { Person, PidXRef } from '~/interfaces/persons'
-import { WorkItem } from '~/interfaces/workitem'
-import { LinkRecordSummary } from '~/interfaces/linkrecords'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { defineComponent, ref, useContext, watch } from "@nuxtjs/composition-api";
+import useModal from "@/helpers/useModal";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { PatientRecord, PatientRecordFull } from "~/interfaces/patientrecord";
+import { MasterRecord } from "~/interfaces/masterrecord";
+import { Person, PidXRef } from "~/interfaces/persons";
+import { WorkItem } from "~/interfaces/workitem";
+import { LinkRecordSummary } from "~/interfaces/linkrecords";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 interface DeletePIDFromEMPISchema {
-  persons: Person[]
-  masterRecords: MasterRecord[]
-  pidxrefs: PidXRef[]
-  workItems: WorkItem[]
-  linkRecords: LinkRecordSummary[]
+  persons: Person[];
+  masterRecords: MasterRecord[];
+  pidxrefs: PidXRef[];
+  workItems: WorkItem[];
+  linkRecords: LinkRecordSummary[];
 }
 
 interface DeletePIDResponseSchema {
-  hash: string
-  committed: boolean
+  hash: string;
+  committed: boolean;
 
-  patientRecord: PatientRecordFull
-  empi: DeletePIDFromEMPISchema
+  patientRecord: PatientRecordFull;
+  empi: DeletePIDFromEMPISchema;
 }
 
 export default defineComponent({
@@ -236,65 +236,65 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
-    const { $toast } = useContext()
-    const { visible, show, hide, toggle } = useModal()
-    const { postPatientRecordDelete } = fetchPatientRecords()
+    const { $toast } = useContext();
+    const { visible, show, hide, toggle } = useModal();
+    const { postPatientRecordDelete } = fetchPatientRecords();
 
-    const confirmChecked = ref(false)
-    const previewResponse = ref<DeletePIDResponseSchema>()
-    const deleteResponse = ref<DeletePIDResponseSchema>()
-    const previewErrorMessage = ref<string>()
-    const deleteInProgress = ref(false)
+    const confirmChecked = ref(false);
+    const previewResponse = ref<DeletePIDResponseSchema>();
+    const deleteResponse = ref<DeletePIDResponseSchema>();
+    const previewErrorMessage = ref<string>();
+    const deleteInProgress = ref(false);
 
     function cancel(): void {
-      emit('cancel')
-      hide()
+      emit("cancel");
+      hide();
     }
 
     watch(visible, async () => {
       // If the modal becomes visible
       if (visible.value) {
         // Reset the modal each time it's is shown.
-        confirmChecked.value = false
-        previewResponse.value = undefined
-        deleteResponse.value = undefined
+        confirmChecked.value = false;
+        previewResponse.value = undefined;
+        deleteResponse.value = undefined;
 
         try {
           // Fetch the delete preview and confirmation hash
-          previewResponse.value = await postPatientRecordDelete(props.item, null)
+          previewResponse.value = await postPatientRecordDelete(props.item, null);
         } catch (error: any) {
           // Populate error message if preview fails
           if (error.response.status === 400) {
-            previewErrorMessage.value = error.response.data.detail
+            previewErrorMessage.value = error.response.data.detail;
           }
         }
       }
-    })
+    });
 
     async function doRealDelete() {
       // Emit confirm event (currently unused)
-      emit('confirm')
+      emit("confirm");
       // If the checkbox is checked and we have a preview response
       if (confirmChecked.value && previewResponse.value) {
         // Start the delete spinner
-        deleteInProgress.value = true
+        deleteInProgress.value = true;
         // Request an actual delete by sending the confirmation hash
-        previewResponse.value = await postPatientRecordDelete(props.item, previewResponse.value.hash)
+        previewResponse.value = await postPatientRecordDelete(props.item, previewResponse.value.hash);
       }
       // Remove the delete spinner
-      deleteInProgress.value = false
+      deleteInProgress.value = false;
       // Hide the modal
-      hide()
+      hide();
       // Emit an event notifying parents that a record has been deleted
-      emit('deleted')
+      emit("deleted");
       // Show success toast
       $toast.show({
-        type: 'success',
-        title: 'Success',
-        message: 'Record deleted',
+        type: "success",
+        title: "Success",
+        message: "Record deleted",
         timeout: 5,
-        classTimeout: 'bg-green-600',
-      })
+        classTimeout: "bg-green-600",
+      });
     }
 
     return {
@@ -310,7 +310,7 @@ export default defineComponent({
       hide,
       toggle,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/patientrecords/DetailCards.vue
+++ b/components/patientrecords/DetailCards.vue
@@ -22,13 +22,13 @@
             <div>
               <TextL1> Date of Death </TextL1>
               <TextP>
-                {{ record.patient.deathTime ? formatDate(record.patient.deathTime, (t = false)) : 'N/A' }}
+                {{ record.patient.deathTime ? formatDate(record.patient.deathTime, (t = false)) : "N/A" }}
               </TextP>
             </div>
             <div>
               <TextL1> Ethnicity </TextL1>
               <TextP>
-                {{ record.patient.ethnicGroupDescription || record.patient.ethnicGroupCode || 'Unknown' }}
+                {{ record.patient.ethnicGroupDescription || record.patient.ethnicGroupCode || "Unknown" }}
               </TextP>
             </div>
           </GenericCardMini>
@@ -142,7 +142,7 @@
         >
           <GenericCardMini class="w-full px-4 py-2">
             <TextB>{{ info.type }} Information</TextB>
-            <TextP>{{ info.gpname || 'GP name not known' }}</TextP>
+            <TextP>{{ info.gpname || "GP name not known" }}</TextP>
             <TextP>{{ info.street }}</TextP>
             <LinkPostCode v-if="info.postcode" :code="info.postcode" />
             <TextP>Contact {{ info.contactvalue }}</TextP>
@@ -151,7 +151,7 @@
         <li v-if="!record.patient.familydoctor.gpInfo">
           <GenericCardMini class="w-full px-4 py-2">
             <TextB>GP Information</TextB>
-            <TextP>{{ record.patient.familydoctor.gpname || 'GP name not known' }}</TextP>
+            <TextP>{{ record.patient.familydoctor.gpname || "GP name not known" }}</TextP>
             <TextP>{{ record.patient.familydoctor.street }}</TextP>
             <LinkPostCode v-if="record.patient.familydoctor.postcode" :code="record.patient.familydoctor.postcodee" />
             <TextP>Contact {{ record.patient.familydoctor.contactvalue }}</TextP>
@@ -163,13 +163,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
-import { isEmptyObject } from '@/helpers/utils/objectUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
+import { isEmptyObject } from "@/helpers/utils/objectUtils";
 
-import { PatientRecord } from '@/interfaces/patientrecord'
+import { PatientRecord } from "@/interfaces/patientrecord";
 
 export default defineComponent({
   props: {
@@ -188,9 +188,9 @@ export default defineComponent({
       formatDate,
       formatGender,
       isEmptyObject,
-    }
+    };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/components/patientrecords/GroupedList.vue
+++ b/components/patientrecords/GroupedList.vue
@@ -59,18 +59,18 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
-import { PatientRecordSummary } from '@/interfaces/patientrecord'
+import { PatientRecordSummary } from "@/interfaces/patientrecord";
 
-import { isData, isMembership, isMigrated, isSurvey, isTracing } from '@/helpers/utils/recordUtils'
+import { isData, isMembership, isMigrated, isSurvey, isTracing } from "@/helpers/utils/recordUtils";
 
 interface PRGroups {
-  data: PatientRecordSummary[]
-  surveys: PatientRecordSummary[]
-  migrated: PatientRecordSummary[]
-  memberships: PatientRecordSummary[]
-  tracing: PatientRecordSummary[]
+  data: PatientRecordSummary[];
+  surveys: PatientRecordSummary[];
+  migrated: PatientRecordSummary[];
+  memberships: PatientRecordSummary[];
+  tracing: PatientRecordSummary[];
 }
 
 export default defineComponent({
@@ -89,7 +89,7 @@ export default defineComponent({
           migrated: [],
           memberships: [],
           tracing: [],
-        } as PRGroups
+        } as PRGroups;
       }
 
       return {
@@ -98,27 +98,27 @@ export default defineComponent({
         migrated: props.records.filter(isMigrated),
         memberships: props.records.filter(isMembership),
         tracing: props.records.filter(isTracing),
-      } as PRGroups
-    })
+      } as PRGroups;
+    });
 
     const hasPVMembership = computed(() => {
-      return props.records.some((r) => r.sendingfacility === 'PV')
-    })
+      return props.records.some((r) => r.sendingfacility === "PV");
+    });
 
     const hasPKBMembership = computed(() => {
-      return props.records.some((r) => r.sendingfacility === 'PKB')
-    })
+      return props.records.some((r) => r.sendingfacility === "PKB");
+    });
 
     const hasRADARMembership = computed(() => {
-      return props.records.some((r) => r.sendingextract === 'RADAR')
-    })
+      return props.records.some((r) => r.sendingextract === "RADAR");
+    });
 
     return {
       groupedRecords,
       hasPVMembership,
       hasPKBMembership,
       hasRADARMembership,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/patientrecords/ListItem.vue
+++ b/components/patientrecords/ListItem.vue
@@ -34,7 +34,7 @@
       <div class="flex flex-shrink-0 items-center gap-2 pr-2">
         <div class="flex flex-grow flex-col-reverse gap-2 xl:flex-row">
           <GenericButtonMini class="h-8 truncate" @click="showDetail = !showDetail">
-            {{ showDetail ? 'Hide Record' : 'Peek Record' }}
+            {{ showDetail ? "Hide Record" : "Peek Record" }}
           </GenericButtonMini>
           <GenericButtonMini :to="`/patientrecords/${item.pid}`" class="h-8 truncate"> Open Record </GenericButtonMini>
         </div>
@@ -56,15 +56,15 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGenderCharacter } from '@/helpers/utils/codeUtils'
-import { PatientRecordSummary } from '@/interfaces/patientrecord'
-import { firstMRN } from '~/helpers/utils/recordUtils'
+import { defineComponent, ref, computed } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGenderCharacter } from "@/helpers/utils/codeUtils";
+import { PatientRecordSummary } from "@/interfaces/patientrecord";
+import { firstMRN } from "~/helpers/utils/recordUtils";
 
 interface localNumber {
-  label: string
-  number: string
+  label: string;
+  number: string;
 }
 
 export default defineComponent({
@@ -85,13 +85,13 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const showDetail = ref(false)
+    const showDetail = ref(false);
 
     const firstMRNObject = computed<localNumber>(() => {
-      return firstMRN(props.item)
-    })
+      return firstMRN(props.item);
+    });
 
-    return { showDetail, formatDate, formatGenderCharacter, firstMRNObject }
+    return { showDetail, formatDate, formatGenderCharacter, firstMRNObject };
   },
-})
+});
 </script>

--- a/components/patientrecords/ManageMenu.vue
+++ b/components/patientrecords/ManageMenu.vue
@@ -27,11 +27,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, useContext } from '@nuxtjs/composition-api'
-import { PatientRecordSummary } from '@/interfaces/patientrecord'
-import { modalInterface } from '~/interfaces/modal'
-import usePermissions from '~/helpers/usePermissions'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { defineComponent, ref, useContext } from "@nuxtjs/composition-api";
+import { PatientRecordSummary } from "@/interfaces/patientrecord";
+import { modalInterface } from "~/interfaces/modal";
+import usePermissions from "~/helpers/usePermissions";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   props: {
@@ -51,16 +51,16 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { $toast } = useContext()
-    const { hasPermission } = usePermissions()
-    const { postPatientRecordExport } = fetchPatientRecords()
+    const { $toast } = useContext();
+    const { hasPermission } = usePermissions();
+    const { postPatientRecordExport } = fetchPatientRecords();
 
-    const deleteModal = ref<modalInterface>()
+    const deleteModal = ref<modalInterface>();
 
-    const showMenu = ref(false)
+    const showMenu = ref(false);
 
     function closeMenu() {
-      showMenu.value = false
+      showMenu.value = false;
     }
 
     function copyPID() {
@@ -68,39 +68,39 @@ export default defineComponent({
         .writeText(props.item.pid)
         .then(() => {
           $toast.show({
-            type: 'success',
-            title: 'Success',
-            message: 'PID copied to clipboard',
+            type: "success",
+            title: "Success",
+            message: "PID copied to clipboard",
             timeout: 5,
-            classTimeout: 'bg-green-600',
-          })
+            classTimeout: "bg-green-600",
+          });
         })
         .finally(() => {
-          closeMenu()
-        })
+          closeMenu();
+        });
     }
 
     function actionExport(scope: string) {
       postPatientRecordExport(props.item, scope)
         .then(() => {
           $toast.show({
-            type: 'success',
-            title: 'Success',
-            message: 'Export initiated',
-            classTimeout: 'bg-green-600',
-          })
+            type: "success",
+            title: "Success",
+            message: "Export initiated",
+            classTimeout: "bg-green-600",
+          });
         })
         .finally(() => {
-          closeMenu()
-        })
+          closeMenu();
+        });
     }
 
     function showDeleteModal() {
-      closeMenu()
-      deleteModal.value?.show()
+      closeMenu();
+      deleteModal.value?.show();
     }
 
-    return { deleteModal, showMenu, closeMenu, copyPID, actionExport, showDeleteModal, hasPermission }
+    return { deleteModal, showMenu, closeMenu, copyPID, actionExport, showDeleteModal, hasPermission };
   },
-})
+});
 </script>

--- a/components/patientrecords/document/ListItem.vue
+++ b/components/patientrecords/document/ListItem.vue
@@ -8,12 +8,12 @@
             {{ item.documentname || item.id }}
           </TextL1>
           <TextL1 class="truncate md:inline">
-            {{ item.channel ? `on ${item.channel}` : '' }}
+            {{ item.channel ? `on ${item.channel}` : "" }}
           </TextL1>
         </div>
         <div class="mt-2 flex">
           <span class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800">
-            {{ item.filetype || 'text' }}
+            {{ item.filetype || "text" }}
           </span>
           <TextP class="ml-2 flex-grow line-clamp-1">
             {{ item.filename || `${item.documentname}.txt` }}
@@ -24,12 +24,12 @@
       <div class="col-span-1">
         <TextL1>Entered By</TextL1>
         <TextP class="mt-2">
-          {{ item.enteredbydesc || 'Unknown' }}
+          {{ item.enteredbydesc || "Unknown" }}
         </TextP>
       </div>
       <!-- Origin  -->
       <div class="col-span-1">
-        <TextP>From {{ item.enteredatcode ? item.enteredatcode : 'Unknown source' }}</TextP>
+        <TextP>From {{ item.enteredatcode ? item.enteredatcode : "Unknown source" }}</TextP>
         <TextP class="mt-2">
           {{ formatDate(item.documenttime) }}
         </TextP>
@@ -39,9 +39,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { PatientDocumentSummary } from '~/interfaces/document'
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { PatientDocumentSummary } from "~/interfaces/document";
+import { formatDate } from "@/helpers/utils/dateUtils";
 
 export default defineComponent({
   props: {
@@ -51,7 +51,7 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>

--- a/components/patientrecords/laborder/Card.vue
+++ b/components/patientrecords/laborder/Card.vue
@@ -8,7 +8,7 @@
         {{
           item.specimenCollectedTime
             ? `Collected ${formatDate(item.specimenCollectedTime, (t = true))}`
-            : 'No collection time found'
+            : "No collection time found"
         }}
       </TextP>
     </div>
@@ -20,11 +20,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { LabOrderShort } from '~/interfaces/laborder'
+import { LabOrderShort } from "~/interfaces/laborder";
 
 export default defineComponent({
   props: {
@@ -34,7 +34,7 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>

--- a/components/patientrecords/medication/Card.vue
+++ b/components/patientrecords/medication/Card.vue
@@ -26,12 +26,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
 
-import { Medication } from '@/interfaces/medication'
+import { Medication } from "@/interfaces/medication";
 
 export default defineComponent({
   props: {
@@ -41,7 +41,7 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate, formatGender }
+    return { formatDate, formatGender };
   },
-})
+});
 </script>

--- a/components/patientrecords/observation/Card.vue
+++ b/components/patientrecords/observation/Card.vue
@@ -15,11 +15,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { Observation } from '@/interfaces/observation'
+import { Observation } from "@/interfaces/observation";
 
 export default defineComponent({
   props: {
@@ -29,9 +29,9 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/components/patientrecords/observation/TableRow.vue
+++ b/components/patientrecords/observation/TableRow.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { Observation } from '@/interfaces/observation'
+import { defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { Observation } from "@/interfaces/observation";
 
 export default defineComponent({
   props: {
@@ -24,9 +24,9 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/components/patientrecords/result/Card.vue
+++ b/components/patientrecords/result/Card.vue
@@ -19,11 +19,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { ResultItem } from '~/interfaces/laborder'
+import { ResultItem } from "~/interfaces/laborder";
 
 export default defineComponent({
   props: {
@@ -33,7 +33,7 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>

--- a/components/patientrecords/result/Row.vue
+++ b/components/patientrecords/result/Row.vue
@@ -17,7 +17,7 @@
       </div>
     </td>
     <td class="whitespace-nowrap px-6 py-4 text-gray-500">
-      {{ item.observationTime ? formatDate(item.observationTime) : 'No Observation Time' }}
+      {{ item.observationTime ? formatDate(item.observationTime) : "No Observation Time" }}
     </td>
     <td class="text-gray-500">
       <GenericButtonRound
@@ -32,11 +32,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { ResultItem } from '~/interfaces/laborder'
+import { ResultItem } from "~/interfaces/laborder";
 
 export default defineComponent({
   props: {
@@ -46,7 +46,7 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>

--- a/components/patientrecords/survey/Viewer.vue
+++ b/components/patientrecords/survey/Viewer.vue
@@ -42,7 +42,7 @@
       <div v-for="(questions, group) in groupedQuestions" :key="group">
         <div class="mb-6 sm:rounded-lg">
           <h3 class="mb-4 text-lg font-medium leading-6 text-gray-900">
-            {{ group !== 'null' ? group : 'Ungrouped' }}
+            {{ group !== "null" ? group : "Ungrouped" }}
           </h3>
           <div class="border-t border-gray-200">
             <GenericCardDl>
@@ -68,47 +68,47 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { Survey, SurveyQuestion } from '@/interfaces/survey'
-import { modalInterface } from '@/interfaces/modal'
+import { Survey, SurveyQuestion } from "@/interfaces/survey";
+import { modalInterface } from "@/interfaces/modal";
 
 interface GroupedQuestions {
-  [key: string]: SurveyQuestion[]
+  [key: string]: SurveyQuestion[];
 }
 
 export default defineComponent({
   setup() {
-    const survey = ref({} as Survey)
+    const survey = ref({} as Survey);
     const availableToOpen = computed(() => {
-      return !(Object.keys(survey.value).length === 0)
-    })
+      return !(Object.keys(survey.value).length === 0);
+    });
     const groupedQuestions = computed(() => {
       if (!survey.value.questions) {
-        return {}
+        return {};
       }
-      const groups = {} as GroupedQuestions
+      const groups = {} as GroupedQuestions;
       for (const question of survey.value.questions) {
         if (!(question.questionGroup in groups)) {
-          groups[question.questionGroup] = []
+          groups[question.questionGroup] = [];
         }
-        groups[question.questionGroup].push(question)
+        groups[question.questionGroup].push(question);
       }
-      return groups
-    })
+      return groups;
+    });
 
-    const surveyViewerModal = ref<modalInterface>()
+    const surveyViewerModal = ref<modalInterface>();
     function hide(): void {
-      surveyViewerModal.value?.hide()
+      surveyViewerModal.value?.hide();
     }
     function toggle(): void {
-      surveyViewerModal.value?.toggle()
+      surveyViewerModal.value?.toggle();
     }
     function show(surveyToShow: Survey): void {
-      survey.value = surveyToShow
-      surveyViewerModal.value?.show()
+      survey.value = surveyToShow;
+      surveyViewerModal.value?.show();
     }
 
     return {
@@ -120,9 +120,9 @@ export default defineComponent({
       toggle,
       show,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>
 
 <style scoped>

--- a/components/persons/RecordCard.vue
+++ b/components/persons/RecordCard.vue
@@ -24,7 +24,7 @@
               `${realLocalID.sendingFacility ? realLocalID.sendingFacility : record.localidType}`
             }}</span>
             <span :class="highlight.includes('sendingExtract') ? highlightClasses : []">{{
-              `${realLocalID.sendingExtract ? 'via ' + realLocalID.sendingExtract : ''}`
+              `${realLocalID.sendingExtract ? "via " + realLocalID.sendingExtract : ""}`
             }}</span>
           </GenericCardDd>
         </GenericCardDi>
@@ -52,7 +52,7 @@
             class="mt-1 text-gray-900 sm:col-span-2 sm:mt-0"
             :class="highlight.includes('dateOfDeath') ? highlightClasses : []"
           >
-            {{ record.dateOfDeath ? formatDate(record.dateOfDeath, (t = false)) : 'N/A' }}
+            {{ record.dateOfDeath ? formatDate(record.dateOfDeath, (t = false)) : "N/A" }}
           </dd>
         </GenericCardDi>
       </GenericCardDl>
@@ -61,16 +61,16 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
 
-import { Person } from '@/interfaces/persons'
+import { Person } from "@/interfaces/persons";
 
 interface realLocalId {
-  localid: string
-  sendingExtract?: string
-  sendingFacility?: string
+  localid: string;
+  sendingExtract?: string;
+  sendingFacility?: string;
 }
 
 export default defineComponent({
@@ -93,21 +93,21 @@ export default defineComponent({
 
   setup(props) {
     const highlightClasses = [
-      'bg-red-100',
-      'text-red-800',
-      'font-medium',
-      'rounded-md',
-      'pl-2',
-      '-ml-2',
-      'pr-2',
-      'mr-2',
-    ]
+      "bg-red-100",
+      "text-red-800",
+      "font-medium",
+      "rounded-md",
+      "pl-2",
+      "-ml-2",
+      "pr-2",
+      "mr-2",
+    ];
 
     const realLocalID = computed<realLocalId>(() => {
-      if (props.record.localidType !== 'CLPID') {
+      if (props.record.localidType !== "CLPID") {
         return {
           localid: props.record.localid,
-        }
+        };
       }
       for (const xref of props.record.xrefEntries) {
         if (xref.pid === props.record.localid) {
@@ -115,15 +115,15 @@ export default defineComponent({
             localid: xref.localid,
             sendingExtract: xref.sendingExtract,
             sendingFacility: xref.sendingFacility,
-          }
+          };
         }
       }
       return {
         localid: props.record.localid,
-      }
-    })
+      };
+    });
 
-    return { formatDate, formatGender, highlightClasses, realLocalID }
+    return { formatDate, formatGender, highlightClasses, realLocalID };
   },
-})
+});
 </script>

--- a/components/profile/Badge.vue
+++ b/components/profile/Badge.vue
@@ -60,9 +60,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref } from "@nuxtjs/composition-api";
 
-import useAuth from '~/helpers/useAuth'
+import useAuth from "~/helpers/useAuth";
 
 export default defineComponent({
   props: {
@@ -78,21 +78,21 @@ export default defineComponent({
     },
   },
   setup() {
-    const { signedIn, getIdToken, signOut } = useAuth()
+    const { signedIn, getIdToken, signOut } = useAuth();
 
-    const showMenu = ref(false)
+    const showMenu = ref(false);
 
     function closeMenu() {
-      showMenu.value = false
+      showMenu.value = false;
     }
 
     const displayName = computed(() => {
-      const idToken = getIdToken()
+      const idToken = getIdToken();
       if (idToken) {
-        return idToken.payload.name
+        return idToken.payload.name;
       }
-      return 'Signed Out'
-    })
+      return "Signed Out";
+    });
 
     return {
       signedIn,
@@ -100,9 +100,9 @@ export default defineComponent({
       showMenu,
       closeMenu,
       signOut,
-    }
+    };
   },
-})
+});
 </script>
 
 <style></style>

--- a/components/text/NameH1.vue
+++ b/components/text/NameH1.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -19,5 +19,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/text/NameH2.vue
+++ b/components/text/NameH2.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -29,11 +29,11 @@ export default defineComponent({
     },
   },
   setup() {
-    const highlightClasses = ['bg-red-100', 'text-red-800', 'font-medium', 'rounded-md']
+    const highlightClasses = ["bg-red-100", "text-red-800", "font-medium", "rounded-md"];
 
     return {
       highlightClasses,
-    }
+    };
   },
-})
+});
 </script>

--- a/components/text/NameL1.vue
+++ b/components/text/NameL1.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -19,5 +19,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/toast/Icon.vue
+++ b/components/toast/Icon.vue
@@ -63,9 +63,9 @@ export default {
       type: String,
       required: false,
       validate: (type) => {
-        return ['success', 'info', 'danger', 'warning', 'denied'].includes(type)
+        return ["success", "info", "danger", "warning", "denied"].includes(type);
       },
-      default: '',
+      default: "",
     },
     icon: {
       type: [Boolean, String],
@@ -73,5 +73,5 @@ export default {
       default: false,
     },
   },
-}
+};
 </script>

--- a/components/tracing/Badge.vue
+++ b/components/tracing/Badge.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   props: {
@@ -13,5 +13,5 @@ export default defineComponent({
       required: true,
     },
   },
-})
+});
 </script>

--- a/components/workitems/AdviceCard.vue
+++ b/components/workitems/AdviceCard.vue
@@ -70,15 +70,15 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, useRoute } from '@nuxtjs/composition-api'
-import { WorkItem, WorkItemExtended } from '@/interfaces/workitem'
+import { computed, defineComponent, useRoute } from "@nuxtjs/composition-api";
+import { WorkItem, WorkItemExtended } from "@/interfaces/workitem";
 import {
   collectionIsUnresolved,
   workItemIsMergable,
   workItemIsOpen,
   workItemIsSecondary,
   workItemIsUKRDC,
-} from '@/helpers/utils/workItemUtils'
+} from "@/helpers/utils/workItemUtils";
 
 export default defineComponent({
   props: {
@@ -95,13 +95,13 @@ export default defineComponent({
   },
   setup(props) {
     const workItemAdvices = computed(() => {
-      const route = useRoute()
+      const route = useRoute();
 
-      const advices: number[] = []
+      const advices: number[] = [];
 
       // If we have no Work Item record, return early
       if (!props.item) {
-        return []
+        return [];
       }
 
       // If workitem is closed
@@ -109,47 +109,47 @@ export default defineComponent({
         // If items in the collection are still open
         if (collectionIsUnresolved(props.related)) {
           // Advise to close related items
-          advices.push(11)
+          advices.push(11);
         } else {
           // Advise no further action
-          advices.push(10)
+          advices.push(10);
         }
         // If item is an open type 9
       } else if (props.item.type === 9) {
         // Advise link to type 9 documentation
-        advices.push(9)
+        advices.push(9);
         // If item is an open type 3 or 6
       } else if (workItemIsUKRDC(props.item)) {
         // If the workitem has records to merge
         if (workItemIsMergable(props.item)) {
           // Advise to check/update demographics, then merge and close
-          advices.push(5)
+          advices.push(5);
           // If the workitem has no records to merge, but was just merged
-        } else if (route.value.query.justMerged === 'true') {
+        } else if (route.value.query.justMerged === "true") {
           // Advise to close the workitem
-          advices.push(6)
+          advices.push(6);
           // If the workitem has no destination record, but was not just merged
         } else if (!props.item.masterRecord) {
           // Advise that the records may have been previously deleted or merged
-          advices.push(12)
+          advices.push(12);
           // If the workitem has no records to merge, but was NOT just merged
         } else {
           // Advise that merge may have been completed with incorrect data
-          advices.push(7)
+          advices.push(7);
         }
         // If item is an open type 4 or 7, and is secondary to others in the collection
       } else if (workItemIsSecondary(props.item, props.related)) {
         // Advise to close related UKRDC items first
-        advices.push(2)
+        advices.push(2);
       } else {
-        advices.push(4)
+        advices.push(4);
       }
 
-      return advices
-    })
-    return { workItemAdvices }
+      return advices;
+    });
+    return { workItemAdvices };
   },
-})
+});
 </script>
 
 <style lang="postcss">

--- a/components/workitems/AttributeRecordCard.vue
+++ b/components/workitems/AttributeRecordCard.vue
@@ -2,10 +2,10 @@
   <GenericCard class="border-2 border-green-500">
     <div class="flex h-24 flex-col justify-center px-4 sm:px-6">
       <div class="text-gray-500" :class="highlight.includes('givenname') ? highlightClasses : []">
-        {{ record.givenname ? formatAttributeValue(record.givenname) : 'Given Name not specified' }}
+        {{ record.givenname ? formatAttributeValue(record.givenname) : "Given Name not specified" }}
       </div>
       <div class="mt-1 text-gray-500" :class="highlight.includes('surname') ? highlightClasses : []">
-        {{ record.surname ? formatAttributeValue(record.surname) : 'Surname not specified' }}
+        {{ record.surname ? formatAttributeValue(record.surname) : "Surname not specified" }}
       </div>
     </div>
     <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
@@ -13,17 +13,17 @@
         <GenericCardDi>
           <GenericCardDt>Local ID</GenericCardDt>
           <GenericCardDd :class="highlight.includes('localid') ? highlightClasses : []">
-            {{ record.localid ? formatAttributeValue(record.localid) : 'Not specified' }}
+            {{ record.localid ? formatAttributeValue(record.localid) : "Not specified" }}
           </GenericCardDd>
         </GenericCardDi>
         <GenericCardDi>
           <GenericCardDt>Sender</GenericCardDt>
           <GenericCardDd>
             <span :class="highlight.includes('sendingFacility') ? highlightClasses : []">{{
-              record.sendingFacility ? record.sendingFacility : ''
+              record.sendingFacility ? record.sendingFacility : ""
             }}</span>
             <span :class="highlight.includes('sendingExtract') ? highlightClasses : []">{{
-              record.sendingExtract ? 'via ' + record.sendingExtract : 'Not specified'
+              record.sendingExtract ? "via " + record.sendingExtract : "Not specified"
             }}</span>
           </GenericCardDd>
         </GenericCardDi>
@@ -51,13 +51,13 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
-import { formatAttributeValue } from '@/helpers/utils/workItemUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
+import { formatAttributeValue } from "@/helpers/utils/workItemUtils";
 
-import { WorkItemAttributes } from '~/interfaces/workitem'
+import { WorkItemAttributes } from "~/interfaces/workitem";
 
 export default defineComponent({
   props: {
@@ -78,39 +78,39 @@ export default defineComponent({
   },
   setup(props) {
     const highlightClasses = [
-      'bg-red-100',
-      'text-red-800',
-      'font-medium',
-      'rounded-md',
-      'pl-2',
-      '-ml-2',
-      'pr-2',
-      'mr-2',
-    ]
+      "bg-red-100",
+      "text-red-800",
+      "font-medium",
+      "rounded-md",
+      "pl-2",
+      "-ml-2",
+      "pr-2",
+      "mr-2",
+    ];
 
     const formattedDoB = computed(() => {
       return props.record.dateOfBirth
         ? `
-        ${formatDate(props.record.dateOfBirth.split(':')[0], false)} →
-        ${formatDate(props.record.dateOfBirth.split(':')[1], false)}`
-        : 'Not specified'
-    })
+        ${formatDate(props.record.dateOfBirth.split(":")[0], false)} →
+        ${formatDate(props.record.dateOfBirth.split(":")[1], false)}`
+        : "Not specified";
+    });
 
     const formattedDoD = computed(() => {
       return props.record.dateOfDeath
         ? `
-        ${formatDate(props.record.dateOfDeath.split(':')[0], false)} →
-        ${formatDate(props.record.dateOfDeath.split(':')[1], false)}`
-        : 'Not specified'
-    })
+        ${formatDate(props.record.dateOfDeath.split(":")[0], false)} →
+        ${formatDate(props.record.dateOfDeath.split(":")[1], false)}`
+        : "Not specified";
+    });
 
     const formattedGender = computed(() => {
       return props.record.gender
         ? `
-        ${formatGender(props.record.gender.split(':')[0])} →
-        ${formatGender(props.record.gender.split(':')[1])}`
-        : 'Not specified'
-    })
+        ${formatGender(props.record.gender.split(":")[0])} →
+        ${formatGender(props.record.gender.split(":")[1])}`
+        : "Not specified";
+    });
 
     return {
       formattedDoB,
@@ -120,9 +120,9 @@ export default defineComponent({
       formatGender,
       formatAttributeValue,
       highlightClasses,
-    }
+    };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/components/workitems/DetailCard.vue
+++ b/components/workitems/DetailCard.vue
@@ -6,21 +6,21 @@
         <GenericDi>
           <TextDt>Last Updated</TextDt>
           <TextDd v-if="item">
-            {{ item.lastUpdated ? formatDate(item.lastUpdated) : 'Never' }}
+            {{ item.lastUpdated ? formatDate(item.lastUpdated) : "Never" }}
           </TextDd>
           <SkeleText v-else class="h-6 w-full" />
         </GenericDi>
         <GenericDi>
           <TextDt>Last Updated By</TextDt>
           <TextDd v-if="item">
-            {{ item.updatedBy ? item.updatedBy : 'N/A' }}
+            {{ item.updatedBy ? item.updatedBy : "N/A" }}
           </TextDd>
           <SkeleText v-else class="h-6 w-full" />
         </GenericDi>
         <GenericDi class="sm:col-span-2">
           <TextDt>Comments</TextDt>
           <TextDd v-if="item">
-            {{ item.updateDescription ? item.updateDescription : 'None' }}
+            {{ item.updateDescription ? item.updateDescription : "None" }}
           </TextDd>
           <SkeleText v-else class="h-6 w-full" />
         </GenericDi>
@@ -30,11 +30,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { WorkItemExtended } from '@/interfaces/workitem'
+import { WorkItemExtended } from "@/interfaces/workitem";
 
 export default defineComponent({
   props: {
@@ -45,7 +45,7 @@ export default defineComponent({
     },
   },
   setup() {
-    return { formatDate }
+    return { formatDate };
   },
-})
+});
 </script>

--- a/components/workitems/ListItem.vue
+++ b/components/workitems/ListItem.vue
@@ -44,9 +44,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { WorkItem } from '@/interfaces/workitem'
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { WorkItem } from "@/interfaces/workitem";
 
 export default defineComponent({
   props: {
@@ -58,19 +58,19 @@ export default defineComponent({
   setup(props) {
     const facility = computed(() => {
       if (props.item.person?.xrefEntries[0]?.sendingFacility) {
-        return props.item.person?.xrefEntries[0]?.sendingFacility
+        return props.item.person?.xrefEntries[0]?.sendingFacility;
       } else {
-        return 'Unknown Facility'
+        return "Unknown Facility";
       }
-    })
+    });
     const extract = computed(() => {
       if (props.item.person?.xrefEntries[0]?.sendingExtract) {
-        return props.item.person?.xrefEntries[0]?.sendingExtract
+        return props.item.person?.xrefEntries[0]?.sendingExtract;
       } else {
-        return 'Unknown Extract'
+        return "Unknown Extract";
       }
-    })
-    return { formatDate, facility, extract }
+    });
+    return { formatDate, facility, extract };
   },
-})
+});
 </script>

--- a/components/workitems/RelatedErrorsList.vue
+++ b/components/workitems/RelatedErrorsList.vue
@@ -25,10 +25,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
-import { Message } from '@/interfaces/messages'
-import { WorkItem } from '~/interfaces/workitem'
-import fetchWorkItems from '~/helpers/fetch/fetchWorkItems'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
+import { Message } from "@/interfaces/messages";
+import { WorkItem } from "~/interfaces/workitem";
+import fetchWorkItems from "~/helpers/fetch/fetchWorkItems";
 
 export default defineComponent({
   props: {
@@ -44,13 +44,13 @@ export default defineComponent({
   },
   setup(props) {
     // Dependencies
-    const { fetchWorkItemMessagesPage } = fetchWorkItems()
+    const { fetchWorkItemMessagesPage } = fetchWorkItems();
 
     // Related errors data
-    const relatedErrors = ref([] as Message[])
-    const relatedErrorsPage = ref(1)
-    const relatedErrorsSize = ref(props.size)
-    const relatedErrorsTotal = ref(0)
+    const relatedErrors = ref([] as Message[]);
+    const relatedErrorsPage = ref(1);
+    const relatedErrorsSize = ref(props.size);
+    const relatedErrorsTotal = ref(0);
 
     async function updateRelatedErrors(): Promise<void> {
       const errorsPage = await fetchWorkItemMessagesPage(
@@ -58,31 +58,31 @@ export default defineComponent({
         relatedErrorsPage.value,
         relatedErrorsSize.value,
         null,
-        ['ERROR'],
+        ["ERROR"],
         null,
         null
-      )
+      );
       // Set related errors
-      relatedErrors.value = errorsPage.items
-      relatedErrorsPage.value = errorsPage.page
-      relatedErrorsSize.value = errorsPage.size
-      relatedErrorsTotal.value = errorsPage.total
+      relatedErrors.value = errorsPage.items;
+      relatedErrorsPage.value = errorsPage.page;
+      relatedErrorsSize.value = errorsPage.size;
+      relatedErrorsTotal.value = errorsPage.total;
     }
 
-    onMounted(updateRelatedErrors)
+    onMounted(updateRelatedErrors);
 
     watch(relatedErrorsPage, () => {
-      updateRelatedErrors()
-    })
+      updateRelatedErrors();
+    });
 
     return {
       relatedErrors,
       relatedErrorsPage,
       relatedErrorsSize,
       relatedErrorsTotal,
-    }
+    };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/helpers/fetch/common.ts
+++ b/helpers/fetch/common.ts
@@ -1,35 +1,35 @@
-import { AuditEvent } from '~/interfaces/audit'
-import { Message } from '~/interfaces/messages'
+import { AuditEvent } from "~/interfaces/audit";
+import { Message } from "~/interfaces/messages";
 
 export interface MessagePage {
-  items: Message[]
-  total: number
-  page: number
-  size: number
+  items: Message[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export interface AuditPage {
-  items: AuditEvent[]
-  total: number
-  page: number
-  size: number
+  items: AuditEvent[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export function buildCommonDateRangeQuery(since: string | null, until: string | null): string {
-  let path = ''
+  let path = "";
   // Filter by since if it exists
   if (since) {
-    path = path + `&since=${encodeURIComponent(since)}`
+    path = path + `&since=${encodeURIComponent(since)}`;
   }
   // Pass `until` to API if it's given
   if (until) {
-    path = path + `&until=${encodeURIComponent(until)}`
+    path = path + `&until=${encodeURIComponent(until)}`;
   } else if (since) {
     // If no `until` is given but a `since` is given, then a single date is selected
     // In this case we want to only show that one day, not a dateRange
-    path = path + `&until=${encodeURIComponent(since)}`
+    path = path + `&until=${encodeURIComponent(since)}`;
   }
-  return path
+  return path;
 }
 
 export function buildCommonMessageQuery(
@@ -38,19 +38,19 @@ export function buildCommonMessageQuery(
   since: string | null,
   until: string | null
 ): string {
-  let path = ''
+  let path = "";
   // Order results
   if (orderBy) {
-    path = path + `&order_by=${orderBy}`
+    path = path + `&order_by=${orderBy}`;
   }
   // Filter by since-until if it exists
-  path = path + buildCommonDateRangeQuery(since, until)
+  path = path + buildCommonDateRangeQuery(since, until);
   // Filter by message status
   if (statuses) {
     for (const status of statuses) {
-      path = path + `&status=${status}`
+      path = path + `&status=${status}`;
     }
   }
 
-  return path
+  return path;
 }

--- a/helpers/fetch/fetchAdmin.ts
+++ b/helpers/fetch/fetchAdmin.ts
@@ -1,34 +1,34 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { buildCommonMessageQuery } from './common'
-import { HistoryItem } from '~/interfaces/common'
-import { AdminCounts } from '~/interfaces/admin'
+import { useContext } from "@nuxtjs/composition-api";
+import { buildCommonMessageQuery } from "./common";
+import { HistoryItem } from "~/interfaces/common";
+import { AdminCounts } from "~/interfaces/admin";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchWorkItemsHistory(since: string | null, until: string | null): Promise<HistoryItem[]> {
-    let path = '/v1/admin/workitems_history/'
+    let path = "/v1/admin/workitems_history/";
     // Filter by date
-    path = path + buildCommonMessageQuery(null, [], since, until)
+    path = path + buildCommonMessageQuery(null, [], since, until);
 
-    return (await $api.$get(path)) as HistoryItem[]
+    return (await $api.$get(path)) as HistoryItem[];
   }
 
   async function fetchErrorsHistory(since: string | null, until: string | null): Promise<HistoryItem[]> {
-    let path = '/v1/admin/errors_history/'
+    let path = "/v1/admin/errors_history/";
     // Filter by date
-    path = path + buildCommonMessageQuery(null, [], since, until)
+    path = path + buildCommonMessageQuery(null, [], since, until);
 
-    return (await $api.$get(path)) as HistoryItem[]
+    return (await $api.$get(path)) as HistoryItem[];
   }
 
   async function fetchAdminCounts(): Promise<AdminCounts> {
-    return (await $api.$get('/v1/admin/counts/')) as AdminCounts
+    return (await $api.$get("/v1/admin/counts/")) as AdminCounts;
   }
 
   return {
     fetchWorkItemsHistory,
     fetchErrorsHistory,
     fetchAdminCounts,
-  }
+  };
 }

--- a/helpers/fetch/fetchCodes.ts
+++ b/helpers/fetch/fetchCodes.ts
@@ -1,20 +1,20 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { Code, ExtendedCode } from '@/interfaces/codes'
+import { useContext } from "@nuxtjs/composition-api";
+import { Code, ExtendedCode } from "@/interfaces/codes";
 
 interface CodesPage {
-  items: Code[]
-  total: number
-  page: number
-  size: number
+  items: Code[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchCodingStandards(): Promise<string[]> {
-    const standardsResponse: string[] = await $api.$get('/v1/codes/standards/')
-    standardsResponse.sort()
-    return standardsResponse
+    const standardsResponse: string[] = await $api.$get("/v1/codes/standards/");
+    standardsResponse.sort();
+    return standardsResponse;
   }
 
   async function fetchCodesPage(
@@ -24,21 +24,21 @@ export default function () {
     search: string | null
   ): Promise<CodesPage> {
     // Fetch code list
-    let path = `/v1/codes/list/?page=${page}&size=${size}`
+    let path = `/v1/codes/list/?page=${page}&size=${size}`;
     // Filter by service if it exists
     if (standard) {
-      path = path + `&coding_standard=${encodeURIComponent(standard)}`
+      path = path + `&coding_standard=${encodeURIComponent(standard)}`;
     }
     // Filter by search term if it exists
     if (search) {
-      path = path + `&search=${encodeURIComponent(search)}`
+      path = path + `&search=${encodeURIComponent(search)}`;
     }
-    return (await $api.$get(path)) as CodesPage
+    return (await $api.$get(path)) as CodesPage;
   }
 
   async function fetchCode(code: string): Promise<ExtendedCode> {
-    return (await $api.$get(`/v1/codes/list/${code}/`)) as ExtendedCode
+    return (await $api.$get(`/v1/codes/list/${code}/`)) as ExtendedCode;
   }
 
-  return { fetchCodingStandards, fetchCodesPage, fetchCode }
+  return { fetchCodingStandards, fetchCodesPage, fetchCode };
 }

--- a/helpers/fetch/fetchDash.ts
+++ b/helpers/fetch/fetchDash.ts
@@ -1,12 +1,12 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { DashResponse } from '@/interfaces/dash'
+import { useContext } from "@nuxtjs/composition-api";
+import { DashResponse } from "@/interfaces/dash";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchDashboard(): Promise<DashResponse> {
-    return (await $api.$get('/v1/dash/')) as DashResponse
+    return (await $api.$get("/v1/dash/")) as DashResponse;
   }
 
-  return { fetchDashboard }
+  return { fetchDashboard };
 }

--- a/helpers/fetch/fetchDataHealth.ts
+++ b/helpers/fetch/fetchDataHealth.ts
@@ -1,22 +1,22 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { LastRunTime } from '~/interfaces/admin'
-import { MultipleUKRDCIDsPage } from '~/interfaces/datahealth'
+import { useContext } from "@nuxtjs/composition-api";
+import { LastRunTime } from "~/interfaces/admin";
+import { MultipleUKRDCIDsPage } from "~/interfaces/datahealth";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchMultipleUKRDCIDsPage(page: number, size: number): Promise<MultipleUKRDCIDsPage> {
     return (await $api.$get(
       `/v1/admin/datahealth/multiple_ukrdcids/?page=${page}&size=${size}`
-    )) as MultipleUKRDCIDsPage
+    )) as MultipleUKRDCIDsPage;
   }
 
   async function fetchMultipleUKRDCIDsLastRun(): Promise<LastRunTime> {
-    return (await $api.$get(`/v1/admin/datahealth/multiple_ukrdcids/last_run`)) as LastRunTime
+    return (await $api.$get(`/v1/admin/datahealth/multiple_ukrdcids/last_run`)) as LastRunTime;
   }
 
   return {
     fetchMultipleUKRDCIDsPage,
     fetchMultipleUKRDCIDsLastRun,
-  }
+  };
 }

--- a/helpers/fetch/fetchEMPI.ts
+++ b/helpers/fetch/fetchEMPI.ts
@@ -1,23 +1,23 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { LinkRecord } from '~/interfaces/linkrecords'
+import { useContext } from "@nuxtjs/composition-api";
+import { LinkRecord } from "~/interfaces/linkrecords";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function PostEMPIUnlink(personId: number, masterId: number, comment?: string): Promise<LinkRecord> {
-    return (await $api.$post('/v1/empi/unlink/', {
+    return (await $api.$post("/v1/empi/unlink/", {
       personId,
       masterId,
-      comment: comment || '',
-    })) as LinkRecord
+      comment: comment || "",
+    })) as LinkRecord;
   }
 
   async function PostEMPIMerge(supersedingId: number, supersededId: number): Promise<void> {
-    return await $api.$post('/v1/empi/merge', {
+    return await $api.$post("/v1/empi/merge", {
       superseding: supersedingId,
       superseded: supersededId,
-    })
+    });
   }
 
-  return { PostEMPIUnlink, PostEMPIMerge }
+  return { PostEMPIUnlink, PostEMPIMerge };
 }

--- a/helpers/fetch/fetchFacilities.ts
+++ b/helpers/fetch/fetchFacilities.ts
@@ -1,32 +1,32 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { buildCommonMessageQuery, MessagePage } from './common'
-import { Facility } from '~/interfaces/facilities'
-import { HistoryItem } from '~/interfaces/common'
+import { useContext } from "@nuxtjs/composition-api";
+import { buildCommonMessageQuery, MessagePage } from "./common";
+import { Facility } from "~/interfaces/facilities";
+import { HistoryItem } from "~/interfaces/common";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchFacilitiesList(
     sortBy: string | null = null,
     orderBy: string | null = null,
     includeEmpty: boolean = true
   ): Promise<Facility[]> {
-    let path = `/v1/facilities/?include_empty=${includeEmpty}`
+    let path = `/v1/facilities/?include_empty=${includeEmpty}`;
     if (sortBy) {
-      path = path + `&sort_by=${sortBy}`
+      path = path + `&sort_by=${sortBy}`;
     }
     if (orderBy) {
-      path = path + `&order_by=${orderBy}`
+      path = path + `&order_by=${orderBy}`;
     }
-    return (await $api.$get(path)) as Facility[]
+    return (await $api.$get(path)) as Facility[];
   }
 
   async function fetchFacility(code: string): Promise<Facility> {
-    return (await $api.$get(`/v1/facilities/${code}`)) as Facility
+    return (await $api.$get(`/v1/facilities/${code}`)) as Facility;
   }
 
   async function fetchFacilityErrorsHistory(facility: Facility): Promise<HistoryItem[]> {
-    return (await $api.$get(facility.links.errorsHistory)) as HistoryItem[]
+    return (await $api.$get(facility.links.errorsHistory)) as HistoryItem[];
   }
 
   async function fetchFacilityPatientsLatestErrorsPage(
@@ -35,11 +35,11 @@ export default function () {
     size: number,
     orderBy: string | null
   ): Promise<MessagePage> {
-    let path = `${facility.links.patientsLatestErrors}?page=${page}&size=${size}&sort_by=received`
+    let path = `${facility.links.patientsLatestErrors}?page=${page}&size=${size}&sort_by=received`;
     // Filter by status and date
-    path = path + buildCommonMessageQuery(orderBy, null, null, null)
-    return (await $api.$get(path)) as MessagePage
+    path = path + buildCommonMessageQuery(orderBy, null, null, null);
+    return (await $api.$get(path)) as MessagePage;
   }
 
-  return { fetchFacilitiesList, fetchFacility, fetchFacilityErrorsHistory, fetchFacilityPatientsLatestErrorsPage }
+  return { fetchFacilitiesList, fetchFacility, fetchFacilityErrorsHistory, fetchFacilityPatientsLatestErrorsPage };
 }

--- a/helpers/fetch/fetchMasterRecords.ts
+++ b/helpers/fetch/fetchMasterRecords.ts
@@ -1,16 +1,16 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { buildCommonMessageQuery, MessagePage, AuditPage, buildCommonDateRangeQuery } from './common'
-import { MasterRecord, MasterRecordStatistics } from '~/interfaces/masterrecord'
-import { MinimalMessage } from '~/interfaces/messages'
-import { PatientRecordSummary } from '~/interfaces/patientrecord'
-import { LinkRecord } from '~/interfaces/linkrecords'
-import { WorkItem } from '~/interfaces/workitem'
+import { useContext } from "@nuxtjs/composition-api";
+import { buildCommonMessageQuery, MessagePage, AuditPage, buildCommonDateRangeQuery } from "./common";
+import { MasterRecord, MasterRecordStatistics } from "~/interfaces/masterrecord";
+import { MinimalMessage } from "~/interfaces/messages";
+import { PatientRecordSummary } from "~/interfaces/patientrecord";
+import { LinkRecord } from "~/interfaces/linkrecords";
+import { WorkItem } from "~/interfaces/workitem";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchMasterRecord(masterRecordId: string): Promise<MasterRecord> {
-    return (await $api.$get(`/v1/masterrecords/${masterRecordId}/`)) as MasterRecord
+    return (await $api.$get(`/v1/masterrecords/${masterRecordId}/`)) as MasterRecord;
   }
 
   async function fetchMasterRecordRelated(
@@ -18,15 +18,15 @@ export default function () {
     excludeSelf: boolean = true,
     nationalIdType: string | null = null
   ): Promise<MasterRecord[]> {
-    let path = `${masterRecord.links.related}?exclude_self=${excludeSelf}`
+    let path = `${masterRecord.links.related}?exclude_self=${excludeSelf}`;
     if (nationalIdType) {
-      path = path + `&nationalid_type=${nationalIdType}`
+      path = path + `&nationalid_type=${nationalIdType}`;
     }
-    return (await $api.$get(path)) as MasterRecord[]
+    return (await $api.$get(path)) as MasterRecord[];
   }
 
   async function fetchMasterRecordStatistics(masterRecord: MasterRecord): Promise<MasterRecordStatistics> {
-    return (await $api.$get(masterRecord.links.statistics)) as MasterRecordStatistics
+    return (await $api.$get(masterRecord.links.statistics)) as MasterRecordStatistics;
   }
 
   async function fetchMasterRecordMessagesPage(
@@ -38,26 +38,26 @@ export default function () {
     since: string | null,
     until: string | null
   ): Promise<MessagePage> {
-    let path = `${masterRecord.links.messages}?page=${page}&size=${size}&sort_by=received`
+    let path = `${masterRecord.links.messages}?page=${page}&size=${size}&sort_by=received`;
     // Filter by status and date
-    path = path + buildCommonMessageQuery(orderBy, statuses, since, until)
-    return (await $api.$get(path)) as MessagePage
+    path = path + buildCommonMessageQuery(orderBy, statuses, since, until);
+    return (await $api.$get(path)) as MessagePage;
   }
 
   async function fetchMasterRecordLatestMessage(masterRecord: MasterRecord): Promise<MinimalMessage | null> {
-    return ((await $api.$get(masterRecord.links.latestMessage)) as MinimalMessage) || null
+    return ((await $api.$get(masterRecord.links.latestMessage)) as MinimalMessage) || null;
   }
 
   async function fetchMasterRecordPatientRecords(masterRecord: MasterRecord): Promise<PatientRecordSummary[]> {
-    return (await $api.$get(masterRecord.links.patientrecords)) as PatientRecordSummary[]
+    return (await $api.$get(masterRecord.links.patientrecords)) as PatientRecordSummary[];
   }
 
   async function fetchMasterRecordLinkRecords(masterRecord: MasterRecord): Promise<LinkRecord[]> {
-    return (await $api.$get(masterRecord.links.linkrecords)) as LinkRecord[]
+    return (await $api.$get(masterRecord.links.linkrecords)) as LinkRecord[];
   }
 
   async function fetchMasterRecordWorkItems(masterRecord: MasterRecord): Promise<WorkItem[]> {
-    return (await $api.$get(masterRecord.links.workitems)) as WorkItem[]
+    return (await $api.$get(masterRecord.links.workitems)) as WorkItem[];
   }
 
   async function fetchMasterRecordAuditPage(
@@ -68,13 +68,13 @@ export default function () {
     since: string | null,
     until: string | null
   ): Promise<AuditPage> {
-    let path = `${masterRecord.links.audit}?page=${page}&size=${size}`
-    path = path + buildCommonDateRangeQuery(since, until)
+    let path = `${masterRecord.links.audit}?page=${page}&size=${size}`;
+    path = path + buildCommonDateRangeQuery(since, until);
     // Order results
     if (orderBy) {
-      path = path + `&order_by=${orderBy}`
+      path = path + `&order_by=${orderBy}`;
     }
-    return (await $api.$get(path)) as AuditPage
+    return (await $api.$get(path)) as AuditPage;
   }
 
   return {
@@ -87,5 +87,5 @@ export default function () {
     fetchMasterRecordLinkRecords,
     fetchMasterRecordWorkItems,
     fetchMasterRecordAuditPage,
-  }
+  };
 }

--- a/helpers/fetch/fetchMessages.ts
+++ b/helpers/fetch/fetchMessages.ts
@@ -1,12 +1,12 @@
-import { ref, useContext } from '@nuxtjs/composition-api'
-import { buildCommonMessageQuery, MessagePage } from './common'
-import { MasterRecord } from '~/interfaces/masterrecord'
-import { ErrorSource, Message } from '~/interfaces/messages'
-import { ChannelMessage } from '~/interfaces/mirth'
-import { WorkItem } from '~/interfaces/workitem'
+import { ref, useContext } from "@nuxtjs/composition-api";
+import { buildCommonMessageQuery, MessagePage } from "./common";
+import { MasterRecord } from "~/interfaces/masterrecord";
+import { ErrorSource, Message } from "~/interfaces/messages";
+import { ChannelMessage } from "~/interfaces/mirth";
+import { WorkItem } from "~/interfaces/workitem";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchMessagesPage(
     page: number,
@@ -18,69 +18,69 @@ export default function () {
     facility: string | null,
     nationalId: string | null
   ): Promise<MessagePage> {
-    let path = `/v1/messages/?page=${page}&size=${size}&sort_by=received`
+    let path = `/v1/messages/?page=${page}&size=${size}&sort_by=received`;
 
     // Filter by status and date
-    path = path + buildCommonMessageQuery(orderBy, statuses || ['ERROR'], since, until)
+    path = path + buildCommonMessageQuery(orderBy, statuses || ["ERROR"], since, until);
 
     // Filter by facility if it exists
     if (facility) {
-      path = path + `&facility=${facility}`
+      path = path + `&facility=${facility}`;
     }
     // Filter by national ID if it exists
     if (nationalId) {
-      path = path + `&ni=${nationalId}`
+      path = path + `&ni=${nationalId}`;
     }
 
-    const response: MessagePage = await $api.$get(path)
-    return response
+    const response: MessagePage = await $api.$get(path);
+    return response;
   }
 
   async function fetchMessage(id: string): Promise<Message> {
-    return (await $api.$get(`/v1/messages/${id}`)) as Message
+    return (await $api.$get(`/v1/messages/${id}`)) as Message;
   }
 
   async function fetchMessageMasterRecords(message: Message): Promise<MasterRecord[]> {
-    return (await $api.$get(message.links.masterrecords)) as MasterRecord[]
+    return (await $api.$get(message.links.masterrecords)) as MasterRecord[];
   }
 
   async function fetchMessageWorkItems(message: Message): Promise<WorkItem[]> {
-    return (await $api.$get(message.links.workitems)) as WorkItem[]
+    return (await $api.$get(message.links.workitems)) as WorkItem[];
   }
 
   async function fetchMessageMirth(message: Message): Promise<ChannelMessage> {
-    return (await $api.$get(message.links.mirth)) as ChannelMessage
+    return (await $api.$get(message.links.mirth)) as ChannelMessage;
   }
 
-  const fetchSourceInProgress = ref(false)
+  const fetchSourceInProgress = ref(false);
 
   async function fetchMessageSource(message: Message): Promise<ErrorSource> {
-    fetchSourceInProgress.value = true
+    fetchSourceInProgress.value = true;
     try {
-      const source: ErrorSource = await $api.$get(message.links.source)
-      return source
+      const source: ErrorSource = await $api.$get(message.links.source);
+      return source;
     } finally {
-      fetchSourceInProgress.value = false
+      fetchSourceInProgress.value = false;
     }
   }
 
-  const downloadSourceInProgress = ref(false)
+  const downloadSourceInProgress = ref(false);
 
   function downloadMessageSource(message: Message): void {
-    downloadSourceInProgress.value = true
+    downloadSourceInProgress.value = true;
     $api({
       url: message.links.source,
-      method: 'GET',
-      responseType: 'blob',
+      method: "GET",
+      responseType: "blob",
     }).then((response) => {
-      const url = window.URL.createObjectURL(new Blob([response.data]))
-      const link = document.createElement('a')
-      link.href = url
-      link.setAttribute('download', message.filename || `${message.facility}-{message.id}.txt`)
-      document.body.appendChild(link)
-      link.click()
-      downloadSourceInProgress.value = false
-    })
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", message.filename || `${message.facility}-{message.id}.txt`);
+      document.body.appendChild(link);
+      link.click();
+      downloadSourceInProgress.value = false;
+    });
   }
 
   return {
@@ -93,5 +93,5 @@ export default function () {
     fetchSourceInProgress,
     downloadMessageSource,
     downloadSourceInProgress,
-  }
+  };
 }

--- a/helpers/fetch/fetchMirth.ts
+++ b/helpers/fetch/fetchMirth.ts
@@ -1,16 +1,16 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { ChannelGroup, ChannelMessage } from '~/interfaces/mirth'
+import { useContext } from "@nuxtjs/composition-api";
+import { ChannelGroup, ChannelMessage } from "~/interfaces/mirth";
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchMirthGroups(): Promise<ChannelGroup[]> {
-    return (await $api.$get('/v1/mirth/groups/')) as ChannelGroup[]
+    return (await $api.$get("/v1/mirth/groups/")) as ChannelGroup[];
   }
 
   async function fetchMirthMessage(channelId: string, messageId: string): Promise<ChannelMessage> {
-    return (await $api.$get(`/v1/mirth/channels/${channelId}/messages/${messageId}/`)) as ChannelMessage
+    return (await $api.$get(`/v1/mirth/channels/${channelId}/messages/${messageId}/`)) as ChannelMessage;
   }
 
-  return { fetchMirthGroups, fetchMirthMessage }
+  return { fetchMirthGroups, fetchMirthMessage };
 }

--- a/helpers/fetch/fetchPatientRecords.ts
+++ b/helpers/fetch/fetchPatientRecords.ts
@@ -1,84 +1,84 @@
-import { ref, useContext } from '@nuxtjs/composition-api'
-import { buildCommonDateRangeQuery } from './common'
-import { LabOrder, LabOrderShort, ResultItem } from '~/interfaces/laborder'
-import { LinkRecordSummary } from '~/interfaces/linkrecords'
-import { MasterRecord } from '~/interfaces/masterrecord'
-import { Medication } from '~/interfaces/medication'
-import { Observation } from '~/interfaces/observation'
-import { PatientRecord, PatientRecordSummary, PatientRecordFull } from '~/interfaces/patientrecord'
-import { Person, PidXRef } from '~/interfaces/persons'
-import { Survey } from '~/interfaces/survey'
-import { Treatment } from '~/interfaces/treatment'
-import { WorkItem } from '~/interfaces/workitem'
-import { PatientDocumentSummary, PatientDocument } from '~/interfaces/document'
+import { ref, useContext } from "@nuxtjs/composition-api";
+import { buildCommonDateRangeQuery } from "./common";
+import { LabOrder, LabOrderShort, ResultItem } from "~/interfaces/laborder";
+import { LinkRecordSummary } from "~/interfaces/linkrecords";
+import { MasterRecord } from "~/interfaces/masterrecord";
+import { Medication } from "~/interfaces/medication";
+import { Observation } from "~/interfaces/observation";
+import { PatientRecord, PatientRecordSummary, PatientRecordFull } from "~/interfaces/patientrecord";
+import { Person, PidXRef } from "~/interfaces/persons";
+import { Survey } from "~/interfaces/survey";
+import { Treatment } from "~/interfaces/treatment";
+import { WorkItem } from "~/interfaces/workitem";
+import { PatientDocumentSummary, PatientDocument } from "~/interfaces/document";
 
 export interface ResultsPage {
-  items: ResultItem[]
-  total: number
-  page: number
-  size: number
+  items: ResultItem[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export interface ResultService {
-  id: string
-  description: string
-  standard: string
+  id: string;
+  description: string;
+  standard: string;
 }
 
 export interface LabOrdersPage {
-  items: LabOrderShort[]
-  total: number
-  page: number
-  size: number
+  items: LabOrderShort[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export interface ObservationPage {
-  items: Observation[]
-  total: number
-  page: number
-  size: number
+  items: Observation[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export interface DocumentsPage {
-  items: PatientDocumentSummary[]
-  total: number
-  page: number
-  size: number
+  items: PatientDocumentSummary[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export interface DeletePIDFromEMPISchema {
-  persons: Person[]
-  masterRecords: MasterRecord[]
-  pidxrefs: PidXRef[]
-  workItems: WorkItem[]
-  linkRecords: LinkRecordSummary[]
+  persons: Person[];
+  masterRecords: MasterRecord[];
+  pidxrefs: PidXRef[];
+  workItems: WorkItem[];
+  linkRecords: LinkRecordSummary[];
 }
 
 export interface DeletePIDResponseSchema {
-  hash: string
-  committed: boolean
+  hash: string;
+  committed: boolean;
 
-  patientRecord: PatientRecordFull
-  empi: DeletePIDFromEMPISchema
+  patientRecord: PatientRecordFull;
+  empi: DeletePIDFromEMPISchema;
 }
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchPatientRecord(pid: string): Promise<PatientRecord> {
-    return (await $api.$get(`/v1/patientrecords/${pid}/`)) as PatientRecord
+    return (await $api.$get(`/v1/patientrecords/${pid}/`)) as PatientRecord;
   }
 
   async function fetchPatientRecordRelated(record: PatientRecord): Promise<PatientRecordSummary[]> {
-    return (await $api.$get(record.links.related)) as PatientRecordSummary[]
+    return (await $api.$get(record.links.related)) as PatientRecordSummary[];
   }
 
   async function fetchPatientRecordMedications(record: PatientRecord): Promise<Medication[]> {
-    return (await $api.$get(record.links.medications)) as Medication[]
+    return (await $api.$get(record.links.medications)) as Medication[];
   }
 
   async function fetchPatientRecordTreatments(record: PatientRecord): Promise<Treatment[]> {
-    return (await $api.$get(record.links.treatments)) as Treatment[]
+    return (await $api.$get(record.links.treatments)) as Treatment[];
   }
 
   async function fetchPatientRecordResultsPage(
@@ -90,28 +90,28 @@ export default function () {
     since: string | null,
     until: string | null
   ): Promise<ResultsPage> {
-    let path = `${record.links.results}?page=${page}&size=${size}`
+    let path = `${record.links.results}?page=${page}&size=${size}`;
 
     // Filter by service if it exists
     if (serviceId) {
-      path = path + `&service_id=${serviceId}`
+      path = path + `&service_id=${serviceId}`;
     }
     // Filter by since-until if it exists
-    path = path + buildCommonDateRangeQuery(since, until)
+    path = path + buildCommonDateRangeQuery(since, until);
     // Filter by order ID if it exists
     if (orderId) {
-      path = path + `&order_id=${orderId}`
+      path = path + `&order_id=${orderId}`;
     }
 
-    return (await $api.$get(path)) as ResultsPage
+    return (await $api.$get(path)) as ResultsPage;
   }
 
   async function fetchPatientRecordResultServices(record: PatientRecord): Promise<ResultService[]> {
-    return (await $api.$get(record.links.resultServices)) as ResultService[]
+    return (await $api.$get(record.links.resultServices)) as ResultService[];
   }
 
   async function deletePatientRecordResultItem(item: ResultItem): Promise<void> {
-    await $api.$delete(item.links.self)
+    await $api.$delete(item.links.self);
   }
 
   async function fetchPatientRecordLabOrdersPage(
@@ -119,15 +119,15 @@ export default function () {
     page: number,
     size: number
   ): Promise<LabOrdersPage> {
-    return (await $api.$get(`${record.links.laborders}?page=${page}&size=${size}`)) as LabOrdersPage
+    return (await $api.$get(`${record.links.laborders}?page=${page}&size=${size}`)) as LabOrdersPage;
   }
 
   async function fetchPatientRecordLabOrder(record: PatientRecord, orderId: string): Promise<LabOrder> {
-    return (await $api.$get(`${record.links.laborders}${orderId}`)) as LabOrder
+    return (await $api.$get(`${record.links.laborders}${orderId}`)) as LabOrder;
   }
 
   async function deletePatientRecordLabOrder(order: LabOrderShort): Promise<void> {
-    await $api.$delete(order.links.self)
+    await $api.$delete(order.links.self);
   }
 
   async function fetchPatientRecordObservationsPage(
@@ -136,23 +136,23 @@ export default function () {
     size: number,
     codes: string[] | null
   ): Promise<ObservationPage> {
-    let path = `${record.links.observations}?page=${page}&size=${size}`
+    let path = `${record.links.observations}?page=${page}&size=${size}`;
     if (codes) {
       for (const code of codes) {
         if (code) {
-          path = path + `&code=${code}`
+          path = path + `&code=${code}`;
         }
       }
     }
-    return (await $api.$get(path)) as ObservationPage
+    return (await $api.$get(path)) as ObservationPage;
   }
 
   async function fetchPatientRecordObservationCodes(record: PatientRecord): Promise<string[]> {
-    return (await $api.$get(record.links.observationCodes)) as string[]
+    return (await $api.$get(record.links.observationCodes)) as string[];
   }
 
   async function fetchPatientRecordSurveys(record: PatientRecord): Promise<Survey[]> {
-    return (await $api.$get(record.links.surveys)) as Survey[]
+    return (await $api.$get(record.links.surveys)) as Survey[];
   }
 
   async function fetchPatientRecordDocumentsPage(
@@ -160,56 +160,56 @@ export default function () {
     page: number,
     size: number
   ): Promise<DocumentsPage> {
-    return (await $api.$get(`${record.links.documents}?page=${page}&size=${size}`)) as DocumentsPage
+    return (await $api.$get(`${record.links.documents}?page=${page}&size=${size}`)) as DocumentsPage;
   }
 
   async function fetchPatientRecordDocument(record: PatientRecord, docId: string): Promise<PatientDocument> {
-    return (await $api.$get(`${record.links.documents}${docId}/`)) as PatientDocument
+    return (await $api.$get(`${record.links.documents}${docId}/`)) as PatientDocument;
   }
 
-  const documentDownloadInProgress = ref(false)
+  const documentDownloadInProgress = ref(false);
 
   function downloadPatientRecordDocument(patientDocument: PatientDocument): void {
-    documentDownloadInProgress.value = true
+    documentDownloadInProgress.value = true;
     $api({
       url: patientDocument.links.download,
-      method: 'GET',
-      responseType: 'blob',
+      method: "GET",
+      responseType: "blob",
     }).then((response) => {
-      const url = window.URL.createObjectURL(new Blob([response.data]))
-      const link = document.createElement('a')
-      link.href = url
-      link.setAttribute('download', patientDocument.filename || `${patientDocument.documentname}.txt`)
-      document.body.appendChild(link)
-      link.click()
-      documentDownloadInProgress.value = false
-    })
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", patientDocument.filename || `${patientDocument.documentname}.txt`);
+      document.body.appendChild(link);
+      link.click();
+      documentDownloadInProgress.value = false;
+    });
   }
 
   async function postPatientRecordExport(record: PatientRecordSummary, scope: string | null): Promise<void> {
-    let path: string
+    let path: string;
     switch (scope) {
-      case null || 'pv': {
-        path = record.links.exportPV
-        break
+      case null || "pv": {
+        path = record.links.exportPV;
+        break;
       }
-      case 'docs': {
-        path = record.links.exportPVDocs
-        break
+      case "docs": {
+        path = record.links.exportPVDocs;
+        break;
       }
-      case 'tests': {
-        path = record.links.exportPVTests
-        break
+      case "tests": {
+        path = record.links.exportPVTests;
+        break;
       }
-      case 'RADAR': {
-        path = record.links.exportRADAR
-        break
+      case "RADAR": {
+        path = record.links.exportRADAR;
+        break;
       }
       default: {
-        throw new Error('Invalid scope')
+        throw new Error("Invalid scope");
       }
     }
-    return await $api.$post(path)
+    return await $api.$post(path);
   }
 
   async function postPatientRecordDelete(
@@ -218,7 +218,7 @@ export default function () {
   ): Promise<DeletePIDResponseSchema> {
     return (await $api.$post(record.links.delete, {
       hash: confirmationHash,
-    })) as DeletePIDResponseSchema
+    })) as DeletePIDResponseSchema;
   }
 
   return {
@@ -241,5 +241,5 @@ export default function () {
     fetchPatientRecordSurveys,
     postPatientRecordExport,
     postPatientRecordDelete,
-  }
+  };
 }

--- a/helpers/fetch/fetchSearchResults.ts
+++ b/helpers/fetch/fetchSearchResults.ts
@@ -1,17 +1,17 @@
-import { ref, useContext } from '@nuxtjs/composition-api'
-import { MasterRecord } from '~/interfaces/masterrecord'
+import { ref, useContext } from "@nuxtjs/composition-api";
+import { MasterRecord } from "~/interfaces/masterrecord";
 
 interface MasterRecordPage {
-  items: MasterRecord[]
-  total: number
-  page: number
-  size: number
+  items: MasterRecord[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
-  const searchInProgress = ref(false)
+  const searchInProgress = ref(false);
 
   async function fetchSearchResultsPage(
     queryString: string,
@@ -20,20 +20,20 @@ export default function () {
     showUKRDC: boolean = false,
     onlyUKRDC: boolean = false
   ): Promise<MasterRecordPage> {
-    let path = `/v1/search/?${queryString}&page=${page}&size=${size}`
+    let path = `/v1/search/?${queryString}&page=${page}&size=${size}`;
     if (showUKRDC) {
-      path = path + '&include_ukrdc=true'
+      path = path + "&include_ukrdc=true";
     }
     if (onlyUKRDC) {
-      path = path + `&number_type=UKRDC`
+      path = path + `&number_type=UKRDC`;
     }
 
     // Fetch the search results from our API server
-    searchInProgress.value = true
-    const results: MasterRecordPage = await $api.$get(path)
-    searchInProgress.value = false
-    return results
+    searchInProgress.value = true;
+    const results: MasterRecordPage = await $api.$get(path);
+    searchInProgress.value = false;
+    return results;
   }
 
-  return { fetchSearchResultsPage, searchInProgress }
+  return { fetchSearchResultsPage, searchInProgress };
 }

--- a/helpers/fetch/fetchSystem.ts
+++ b/helpers/fetch/fetchSystem.ts
@@ -1,17 +1,17 @@
-import { useContext } from '@nuxtjs/composition-api'
+import { useContext } from "@nuxtjs/composition-api";
 
 interface serverSystemInfo {
-  githubRef: string
-  githubSha: string
-  deploymentEnv: string
+  githubRef: string;
+  githubSha: string;
+  deploymentEnv: string;
 }
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchServerInfo(): Promise<serverSystemInfo> {
-    return (await $api.$get('/v1/system/info/')) as serverSystemInfo
+    return (await $api.$get("/v1/system/info/")) as serverSystemInfo;
   }
 
-  return { fetchServerInfo }
+  return { fetchServerInfo };
 }

--- a/helpers/fetch/fetchWorkItems.ts
+++ b/helpers/fetch/fetchWorkItems.ts
@@ -1,16 +1,16 @@
-import { useContext } from '@nuxtjs/composition-api'
-import { buildCommonMessageQuery, MessagePage, buildCommonDateRangeQuery } from './common'
-import { WorkItem, WorkItemExtended } from '~/interfaces/workitem'
+import { useContext } from "@nuxtjs/composition-api";
+import { buildCommonMessageQuery, MessagePage, buildCommonDateRangeQuery } from "./common";
+import { WorkItem, WorkItemExtended } from "~/interfaces/workitem";
 
 interface WorkItemPage {
-  items: WorkItem[]
-  total: number
-  page: number
-  size: number
+  items: WorkItem[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export default function () {
-  const { $api } = useContext()
+  const { $api } = useContext();
 
   async function fetchWorkItemsPage(
     page: number,
@@ -21,39 +21,39 @@ export default function () {
     since: string | null,
     until: string | null
   ): Promise<WorkItemPage> {
-    let path = `/v1/workitems/?page=${page}&size=${size}&sort_by=last_updated&order_by=${orderBy}`
+    let path = `/v1/workitems/?page=${page}&size=${size}&sort_by=last_updated&order_by=${orderBy}`;
     // Pass selected statuses to the API
     for (const status of statuses) {
-      path = path + `&status=${status}`
+      path = path + `&status=${status}`;
     }
     // Filter by facility if it exists
     if (facility) {
-      path = path + `&facility=${facility}`
+      path = path + `&facility=${facility}`;
     }
     // Filter by since-until if it exists
-    path = path + buildCommonDateRangeQuery(since, until)
+    path = path + buildCommonDateRangeQuery(since, until);
 
-    return await $api.$get(path)
+    return await $api.$get(path);
   }
 
   async function fetchWorkItem(id: string): Promise<WorkItemExtended> {
-    return (await $api.$get(`/v1/workitems/${id}/`)) as WorkItemExtended
+    return (await $api.$get(`/v1/workitems/${id}/`)) as WorkItemExtended;
   }
 
   async function closeWorkItem(id: string, comment: string): Promise<void> {
     await $api.$post(`/v1/workitems/${id}/close/`, {
       comment,
-    })
+    });
   }
 
   async function putWorkItemComment(id: string, comment: string): Promise<void> {
     await $api.$put(`/v1/workitems/${id}/`, {
       comment,
-    })
+    });
   }
 
   async function fetchWorkItemCollection(workItem: WorkItem): Promise<WorkItem[]> {
-    return (await $api.$get(workItem.links.collection)) as WorkItem[]
+    return (await $api.$get(workItem.links.collection)) as WorkItem[];
   }
 
   async function fetchWorkItemMessagesPage(
@@ -65,10 +65,10 @@ export default function () {
     since: string | null,
     until: string | null
   ): Promise<MessagePage> {
-    let path = `${workItem.links.messages}?page=${page}&size=${size}&sort_by=received`
+    let path = `${workItem.links.messages}?page=${page}&size=${size}&sort_by=received`;
     // Filter by status and date
-    path = path + buildCommonMessageQuery(orderBy, statuses, since, until)
-    return (await $api.$get(path)) as MessagePage
+    path = path + buildCommonMessageQuery(orderBy, statuses, since, until);
+    return (await $api.$get(path)) as MessagePage;
   }
 
   return {
@@ -78,5 +78,5 @@ export default function () {
     putWorkItemComment,
     fetchWorkItemCollection,
     fetchWorkItemMessagesPage,
-  }
+  };
 }

--- a/helpers/query/useDateRange.ts
+++ b/helpers/query/useDateRange.ts
@@ -1,11 +1,11 @@
-import { computed, useRoute, useRouter } from '@nuxtjs/composition-api'
+import { computed, useRoute, useRouter } from "@nuxtjs/composition-api";
 
-import { DateRange } from '~/helpers/utils/dateUtils'
-import { singleQuery } from '~/helpers/utils/queryUtils'
+import { DateRange } from "~/helpers/utils/dateUtils";
+import { singleQuery } from "~/helpers/utils/queryUtils";
 
 export default function () {
-  const route = useRoute()
-  const router = useRouter()
+  const route = useRoute();
+  const router = useRouter();
 
   function makeDateRange(
     defaultStart: string | null,
@@ -18,23 +18,23 @@ export default function () {
         return {
           start: singleQuery(route.value.query.since) || defaultStart,
           end: singleQuery(route.value.query.until) || defaultEnd,
-        }
+        };
       },
       set(newRange: DateRange) {
         if (!newRange) {
-          return
+          return;
         }
 
         const newQuery = Object.assign({}, route.value.query, {
           since: newRange.start,
           until: newRange.end,
-        })
+        });
 
         if (resetPage) {
           // If we use both date and page to filter, we need to
           // reset the page number
           if (newQuery.page) {
-            newQuery.page = '1'
+            newQuery.page = "1";
           }
         }
 
@@ -42,18 +42,18 @@ export default function () {
           router.push({
             path: route.value.path,
             query: newQuery,
-          })
+          });
         } else {
           router.replace({
             path: route.value.path,
             query: newQuery,
-          })
+          });
         }
       },
-    })
+    });
   }
 
   return {
     makeDateRange,
-  }
+  };
 }

--- a/helpers/query/usePagination.ts
+++ b/helpers/query/usePagination.ts
@@ -1,16 +1,16 @@
-import { ref } from '@nuxtjs/composition-api'
-import useQuery from '~/helpers/query/useQuery'
+import { ref } from "@nuxtjs/composition-api";
+import useQuery from "~/helpers/query/useQuery";
 
 export default function () {
-  const { integerQuery } = useQuery()
+  const { integerQuery } = useQuery();
 
-  const page = integerQuery('page', 1, false)
-  const total = ref(0)
-  const size = ref(20)
+  const page = integerQuery("page", 1, false);
+  const total = ref(0);
+  const size = ref(20);
 
   function changePage(newPage: number): void {
-    console.warn('changePage is deprecated. Directly set page value instead')
-    page.value = newPage
+    console.warn("changePage is deprecated. Directly set page value instead");
+    page.value = newPage;
   }
 
   return {
@@ -18,5 +18,5 @@ export default function () {
     total,
     size,
     changePage,
-  }
+  };
 }

--- a/helpers/query/useQuery.ts
+++ b/helpers/query/useQuery.ts
@@ -8,31 +8,31 @@ methods. E.g. boolearQuery will parse the query string
 and return a boolean.
 */
 
-import { computed, useRoute, useRouter } from '@nuxtjs/composition-api'
+import { computed, useRoute, useRouter } from "@nuxtjs/composition-api";
 
-import { singleQuery } from '~/helpers/utils/queryUtils'
+import { singleQuery } from "~/helpers/utils/queryUtils";
 
 export default function () {
-  const route = useRoute()
-  const router = useRouter()
+  const route = useRoute();
+  const router = useRouter();
 
   function pushNewQuery(queryKey: string, newValue: any, history: boolean = true, resetPage: boolean = false) {
     const newQuery = Object.assign({}, route.value.query, {
       [queryKey]: [newValue],
-    })
+    });
     if (resetPage) {
-      newQuery.page = ['1']
+      newQuery.page = ["1"];
     }
     if (history) {
       router.push({
         path: route.value.path,
         query: newQuery,
-      })
+      });
     } else {
       router.replace({
         path: route.value.path,
         query: newQuery,
-      })
+      });
     }
   }
 
@@ -44,47 +44,47 @@ export default function () {
   ) {
     return computed({
       get: (): (string | null)[] => {
-        const val = route.value.query[queryKey]
+        const val = route.value.query[queryKey];
         if (val === undefined) {
-          return defaultValue
+          return defaultValue;
         }
         if (!Array.isArray(val)) {
-          return [val]
+          return [val];
         } else {
-          return val
+          return val;
         }
       },
       set: (newValue: (string | null)[]) => {
         const newQuery = Object.assign({}, route.value.query, {
           [queryKey]: newValue,
-        })
+        });
         if (resetPage) {
-          newQuery.page = ['1']
+          newQuery.page = ["1"];
         }
         if (history) {
           router.push({
             path: route.value.path,
             query: newQuery,
-          })
+          });
         } else {
           router.replace({
             path: route.value.path,
             query: newQuery,
-          })
+          });
         }
       },
-    })
+    });
   }
 
   function booleanQuery(queryKey: string, history: boolean = true, resetPage: boolean = false) {
     return computed({
       get: (): boolean | null => {
-        return singleQuery(route.value.query[queryKey]) === 'true'
+        return singleQuery(route.value.query[queryKey]) === "true";
       },
       set: (newValue: boolean | null) => {
-        pushNewQuery(queryKey, newValue, history, resetPage)
+        pushNewQuery(queryKey, newValue, history, resetPage);
       },
-    })
+    });
   }
 
   function stringQuery(
@@ -95,24 +95,24 @@ export default function () {
   ) {
     return computed({
       get: (): string | null => {
-        const val = singleQuery(route.value.query[queryKey])
+        const val = singleQuery(route.value.query[queryKey]);
         if (val === null || val === undefined) {
-          return defaultValue
+          return defaultValue;
         }
-        return val
+        return val;
       },
       set: (newValue: string | null) => {
         // Check if the query has actually changed
-        const current = singleQuery(route.value.query[queryKey])
+        const current = singleQuery(route.value.query[queryKey]);
         if (current !== null && current !== undefined) {
           // If no change, skip navigation
           if (current === newValue) {
-            return
+            return;
           }
         }
-        pushNewQuery(queryKey, newValue, history, resetPage)
+        pushNewQuery(queryKey, newValue, history, resetPage);
       },
-    })
+    });
   }
 
   function integerQuery(
@@ -123,25 +123,25 @@ export default function () {
   ) {
     return computed({
       get: (): number | null => {
-        const val = singleQuery(route.value.query[queryKey])
+        const val = singleQuery(route.value.query[queryKey]);
         if (val === null || val === undefined) {
-          return defaultValue
+          return defaultValue;
         }
-        return parseInt(val)
+        return parseInt(val);
       },
       set: (newValue: number | null) => {
         // Check if the query has actually changed
-        const current = singleQuery(route.value.query[queryKey])
+        const current = singleQuery(route.value.query[queryKey]);
         if (current !== null && current !== undefined) {
           // If no change, skip navigation
           if (parseInt(current) === newValue) {
-            return
+            return;
           }
         }
-        pushNewQuery(queryKey, newValue, history, resetPage)
+        pushNewQuery(queryKey, newValue, history, resetPage);
       },
-    })
+    });
   }
 
-  return { integerQuery, booleanQuery, stringQuery, arrayQuery }
+  return { integerQuery, booleanQuery, stringQuery, arrayQuery };
 }

--- a/helpers/query/useRecordSearch.ts
+++ b/helpers/query/useRecordSearch.ts
@@ -1,21 +1,21 @@
-import { computed, onMounted, ref, watch } from '@nuxtjs/composition-api'
-import useQuery from '~/helpers/query/useQuery'
+import { computed, onMounted, ref, watch } from "@nuxtjs/composition-api";
+import useQuery from "~/helpers/query/useQuery";
 
 export default function () {
-  const { arrayQuery } = useQuery()
+  const { arrayQuery } = useQuery();
 
   // Array of individual search terms as an array of strings from the URL query
   // This is the primary source for search terms when calling the API
-  const searchTermArray = arrayQuery('search', [], true, true)
+  const searchTermArray = arrayQuery("search", [], true, true);
 
   // Current string value of the search text box
-  const searchboxString = ref('')
+  const searchboxString = ref("");
 
   // Check if all terms in an array are empty
   function arrayIsEmpty(arr: (string | null)[]) {
     return arr.every((t) => {
-      return !t
-    })
+      return !t;
+    });
   }
 
   // Check if there are currently any search terms in the URL query
@@ -30,19 +30,19 @@ export default function () {
       // And the array contains some non-null or empty items
       !arrayIsEmpty(searchTermArray.value)
     ) {
-      return true
+      return true;
     }
-    return false
-  })
+    return false;
+  });
 
   function searchSubmit(): void {
     // Populates the 'search' URL query array from the search text box string.
     // e.g. 'john & 1970-03-01' becomes ['john', '1949-03-01']
     if (searchboxString.value) {
-      const sections: string[] = searchboxString.value.split('&')
+      const sections: string[] = searchboxString.value.split("&");
       searchTermArray.value = sections.map(function (s: string) {
-        return s.trim()
-      })
+        return s.trim();
+      });
     }
   }
 
@@ -51,19 +51,19 @@ export default function () {
     // e.g. ['john', '1949-03-01'] becomes john & 1949-03-01
     // Effectively the inverse of searchSubmit
     if (searchQueryIsPopulated) {
-      let q = ''
+      let q = "";
       for (const term of searchTermArray.value) {
-        q = q.concat(`${term} & `)
+        q = q.concat(`${term} & `);
       }
-      searchboxString.value = q.slice(0, -3) // Remove trailing ' & '
+      searchboxString.value = q.slice(0, -3); // Remove trailing ' & '
     } else {
-      searchboxString.value = ''
+      searchboxString.value = "";
     }
   }
 
   function buildAPIQueryStringFromArray(
     input: (string | null)[] | string,
-    defaultQueryName: string = 'search'
+    defaultQueryName: string = "search"
   ): string {
     // Builds an API query string from an array of search terms.
     // e.g. ['john', '1949-03-01'] becomes search=john&search=1949-03-01
@@ -72,43 +72,43 @@ export default function () {
       // If passed multiple query params as an array
 
       // Initial empty query
-      let q = ''
+      let q = "";
       for (const term of input) {
-        let queryName = defaultQueryName
-        let queryValue: string
+        let queryName = defaultQueryName;
+        let queryValue: string;
 
         if (term) {
-          if (term.includes('=')) {
+          if (term.includes("=")) {
             // If the term contains a query name and value
-            const splitTerm = term.split('=')
-            queryName = splitTerm[0]
-            queryValue = splitTerm[1]
+            const splitTerm = term.split("=");
+            queryName = splitTerm[0];
+            queryValue = splitTerm[1];
           } else {
-            queryName = defaultQueryName
-            queryValue = term
+            queryName = defaultQueryName;
+            queryValue = term;
           }
-          q = q.concat(`${queryName}=${queryValue}&`)
+          q = q.concat(`${queryName}=${queryValue}&`);
         }
       }
-      return q.slice(0, -1) // Remove trailing '&'
+      return q.slice(0, -1); // Remove trailing '&'
     } else {
       // If passed a single query param as a string
-      return `${defaultQueryName}=${input}`
+      return `${defaultQueryName}=${input}`;
     }
   }
 
   // Search query string to be passed to the UKRDC API search
   const apiQueryString = computed(() => {
-    return buildAPIQueryStringFromArray(searchTermArray.value)
-  })
+    return buildAPIQueryStringFromArray(searchTermArray.value);
+  });
 
   watch(searchTermArray, () => {
-    searchApply()
-  })
+    searchApply();
+  });
 
   onMounted(() => {
-    searchApply()
-  })
+    searchApply();
+  });
 
   return {
     searchQueryIsPopulated,
@@ -116,5 +116,5 @@ export default function () {
     searchboxString,
     searchSubmit,
     apiQueryString,
-  }
+  };
 }

--- a/helpers/query/useSortBy.ts
+++ b/helpers/query/useSortBy.ts
@@ -1,30 +1,30 @@
-import { computed } from '@nuxtjs/composition-api'
-import useQuery from '~/helpers/query/useQuery'
+import { computed } from "@nuxtjs/composition-api";
+import useQuery from "~/helpers/query/useQuery";
 
 export default function () {
-  const { stringQuery } = useQuery()
+  const { stringQuery } = useQuery();
 
-  const orderBy = stringQuery('order_by', 'desc', false, true)
+  const orderBy = stringQuery("order_by", "desc", false, true);
 
   const orderAscending = computed(() => {
-    if (orderBy.value === 'asc') {
-      return true
+    if (orderBy.value === "asc") {
+      return true;
     } else {
-      return false
+      return false;
     }
-  })
+  });
 
   function toggleOrder(): string {
-    if (orderBy.value === 'asc') {
-      orderBy.value = 'desc'
+    if (orderBy.value === "asc") {
+      orderBy.value = "desc";
     } else {
-      orderBy.value = 'asc'
+      orderBy.value = "asc";
     }
-    return orderBy.value
+    return orderBy.value;
   }
   return {
     orderAscending,
     orderBy,
     toggleOrder,
-  }
+  };
 }

--- a/helpers/useAuth.ts
+++ b/helpers/useAuth.ts
@@ -2,70 +2,70 @@
 Utility functions to simplify interacting with the Okta Auth SDK.
 */
 
-import { onBeforeUnmount, ref, useContext } from '@nuxtjs/composition-api'
+import { onBeforeUnmount, ref, useContext } from "@nuxtjs/composition-api";
 
-import { OktaAuth, AuthState, UserClaims, JWTObject } from '@okta/okta-auth-js'
+import { OktaAuth, AuthState, UserClaims, JWTObject } from "@okta/okta-auth-js";
 
 export interface UKRDCClaims {
-  'org.ukrdc.permissions': string[]
+  "org.ukrdc.permissions": string[];
 }
 
 export interface UKRDCJWTObject extends JWTObject {
-  payload: UserClaims<UKRDCClaims>
+  payload: UserClaims<UKRDCClaims>;
 }
 
 export default function () {
-  const { $okta, $config } = useContext()
+  const { $okta, $config } = useContext();
 
-  const oktaAuth: OktaAuth = $okta
-  const authState = ref($okta.authStateManager.getAuthState())
+  const oktaAuth: OktaAuth = $okta;
+  const authState = ref($okta.authStateManager.getAuthState());
 
   // HANDLE STATE CHANGES
 
   // When auth state changes, update authState.value
   function _handleAuthStateUpdate(newAuthState: AuthState) {
-    authState.value = Object.assign(authState.value || {}, newAuthState)
+    authState.value = Object.assign(authState.value || {}, newAuthState);
   }
 
   // Subscribe to auth state changes
-  oktaAuth.authStateManager.subscribe(_handleAuthStateUpdate)
+  oktaAuth.authStateManager.subscribe(_handleAuthStateUpdate);
 
   // Unsubscribe from auth state changes when component is destroyed
   onBeforeUnmount(() => {
-    oktaAuth.authStateManager.unsubscribe(_handleAuthStateUpdate)
-  })
+    oktaAuth.authStateManager.unsubscribe(_handleAuthStateUpdate);
+  });
 
   async function signOut() {
     await oktaAuth.signOut({
       postLogoutRedirectUri: `${window.location.origin}${$config.okta.postLogoutRedirectUri}`,
-    })
+    });
   }
 
   function signedIn(): boolean {
-    return (authState.value && authState.value.isAuthenticated) || false
+    return (authState.value && authState.value.isAuthenticated) || false;
   }
 
   function getAccessToken(): UKRDCJWTObject | null {
     if (signedIn()) {
-      const rawAccessToken = oktaAuth.getAccessToken()
-      return rawAccessToken ? (oktaAuth.token.decode(rawAccessToken) as UKRDCJWTObject) : null
+      const rawAccessToken = oktaAuth.getAccessToken();
+      return rawAccessToken ? (oktaAuth.token.decode(rawAccessToken) as UKRDCJWTObject) : null;
     } else {
-      return null
+      return null;
     }
   }
 
   function getIdToken(): JWTObject | null {
     if (signedIn()) {
-      const rawIdToken = oktaAuth.getIdToken()
-      return rawIdToken ? oktaAuth.token.decode(rawIdToken) : null
+      const rawIdToken = oktaAuth.getIdToken();
+      return rawIdToken ? oktaAuth.token.decode(rawIdToken) : null;
     } else {
-      return null
+      return null;
     }
   }
 
   async function getUser(): Promise<{ [key: string]: any }> {
     // Get user info from the /userinfo Okta API endpoint
-    return await oktaAuth.getUser()
+    return await oktaAuth.getUser();
   }
 
   return {
@@ -79,5 +79,5 @@ export default function () {
     getUser,
     // Sign out functionality
     signOut,
-  }
+  };
 }

--- a/helpers/useFacilities.ts
+++ b/helpers/useFacilities.ts
@@ -1,31 +1,31 @@
-import { computed, onMounted, ref } from '@nuxtjs/composition-api'
-import fetchFacilities from './fetch/fetchFacilities'
-import useQuery from '~/helpers/query/useQuery'
-import { Facility } from '~/interfaces/facilities'
+import { computed, onMounted, ref } from "@nuxtjs/composition-api";
+import fetchFacilities from "./fetch/fetchFacilities";
+import useQuery from "~/helpers/query/useQuery";
+import { Facility } from "~/interfaces/facilities";
 
 export default function () {
-  const { stringQuery } = useQuery()
-  const { fetchFacilitiesList } = fetchFacilities()
+  const { stringQuery } = useQuery();
+  const { fetchFacilitiesList } = fetchFacilities();
 
-  const facilities = ref([] as Facility[])
+  const facilities = ref([] as Facility[]);
   const facilityIds = computed(() => {
-    return facilities.value.map(({ id }) => id)
-  })
+    return facilities.value.map(({ id }) => id);
+  });
   const facilityLabels = computed(() => {
-    return facilities.value.map(({ description }) => description)
-  })
-  const selectedFacility = stringQuery('facility', null, true)
+    return facilities.value.map(({ description }) => description);
+  });
+  const selectedFacility = stringQuery("facility", null, true);
 
   async function setFacilities() {
     // If we don't already have a list of available facilties, fetch one
     if (facilities.value.length === 0) {
-      facilities.value = await fetchFacilitiesList()
+      facilities.value = await fetchFacilitiesList();
     }
   }
 
   onMounted(() => {
-    setFacilities()
-  })
+    setFacilities();
+  });
 
   return {
     facilities,
@@ -33,5 +33,5 @@ export default function () {
     facilityLabels,
     selectedFacility,
     fetchFacilities,
-  }
+  };
 }

--- a/helpers/useModal.ts
+++ b/helpers/useModal.ts
@@ -1,16 +1,16 @@
-import { ref } from '@nuxtjs/composition-api'
+import { ref } from "@nuxtjs/composition-api";
 
 export default function () {
-  const visible = ref(false)
+  const visible = ref(false);
 
   function show(): void {
-    visible.value = true
+    visible.value = true;
   }
   function hide(): void {
-    visible.value = false
+    visible.value = false;
   }
   function toggle(): void {
-    visible.value = !visible.value
+    visible.value = !visible.value;
   }
 
   return {
@@ -18,5 +18,5 @@ export default function () {
     show,
     hide,
     toggle,
-  }
+  };
 }

--- a/helpers/usePermissions.ts
+++ b/helpers/usePermissions.ts
@@ -1,46 +1,46 @@
-import { computed } from '@nuxtjs/composition-api'
-import { UserClaims } from '@okta/okta-auth-js'
-import useAuth, { UKRDCClaims } from './useAuth'
+import { computed } from "@nuxtjs/composition-api";
+import { UserClaims } from "@okta/okta-auth-js";
+import useAuth, { UKRDCClaims } from "./useAuth";
 
 export default function () {
-  const { signedIn, getAccessToken } = useAuth()
+  const { signedIn, getAccessToken } = useAuth();
 
   function getPermissions(): string[] {
-    const token = getAccessToken()
+    const token = getAccessToken();
     if (token) {
-      const payload: UserClaims<UKRDCClaims> = token.payload
-      return payload['org.ukrdc.permissions'] as string[]
+      const payload: UserClaims<UKRDCClaims> = token.payload;
+      return payload["org.ukrdc.permissions"] as string[];
     }
 
-    return []
+    return [];
   }
 
   function hasPermission(key: string): boolean {
     if (signedIn()) {
       // Fetch permissions array from the access token
-      const permissions = getPermissions()
+      const permissions = getPermissions();
       if (permissions && permissions.includes(key)) {
-        return true
+        return true;
       }
     }
-    return false
+    return false;
   }
 
   function getFacilities(): string[] {
     if (signedIn()) {
-      const permissions = getPermissions()
+      const permissions = getPermissions();
       if (permissions) {
         return permissions
-          .filter((option) => option.toLowerCase().startsWith('ukrdc:unit:') && option.toLowerCase() !== 'ukrdc:unit:*')
-          .map((option) => option.replace('ukrdc:unit:', ''))
+          .filter((option) => option.toLowerCase().startsWith("ukrdc:unit:") && option.toLowerCase() !== "ukrdc:unit:*")
+          .map((option) => option.replace("ukrdc:unit:", ""));
       }
     }
-    return []
+    return [];
   }
 
-  const isAdmin = computed(() => hasPermission('ukrdc:unit:*'))
+  const isAdmin = computed(() => hasPermission("ukrdc:unit:*"));
 
-  const hasMultipleFacilities = computed(() => getFacilities().length > 1 || isAdmin.value)
+  const hasMultipleFacilities = computed(() => getFacilities().length > 1 || isAdmin.value);
 
-  return { hasPermission, getPermissions, getFacilities, hasMultipleFacilities, isAdmin }
+  return { hasPermission, getPermissions, getFacilities, hasMultipleFacilities, isAdmin };
 }

--- a/helpers/useUserPrefs.ts
+++ b/helpers/useUserPrefs.ts
@@ -1,18 +1,18 @@
-import { computed, useStore } from '@nuxtjs/composition-api'
+import { computed, useStore } from "@nuxtjs/composition-api";
 
 export default function () {
-  const store = useStore()
+  const store = useStore();
 
   const showUKRDC = computed({
     get: () => {
-      return store.getters.searchShowUKRDC
+      return store.getters.searchShowUKRDC;
     },
     set: (newValue: boolean) => {
-      store.commit('changeSearchShowUKRDC', newValue)
+      store.commit("changeSearchShowUKRDC", newValue);
     },
-  })
+  });
 
   return {
     showUKRDC,
-  }
+  };
 }

--- a/helpers/utils/arrayUtils.ts
+++ b/helpers/utils/arrayUtils.ts
@@ -1,3 +1,3 @@
 export function insertIf(condition: boolean, ...elements: any[]) {
-  return condition ? elements : []
+  return condition ? elements : [];
 }

--- a/helpers/utils/chartUtils.ts
+++ b/helpers/utils/chartUtils.ts
@@ -1,8 +1,8 @@
-import { DateTime } from 'luxon'
-import { HistoryPointEvent } from '~/interfaces/charts'
+import { DateTime } from "luxon";
+import { HistoryPointEvent } from "~/interfaces/charts";
 
 export function getPointDateRange(point: HistoryPointEvent) {
-  const startDate = DateTime.fromMillis(point.x)
-  const endDate = startDate.plus({ days: 1 })
-  return { since: startDate.toISO(), until: endDate.toISO() }
+  const startDate = DateTime.fromMillis(point.x);
+  const endDate = startDate.plus({ days: 1 });
+  return { since: startDate.toISO(), until: endDate.toISO() };
 }

--- a/helpers/utils/codeUtils.ts
+++ b/helpers/utils/codeUtils.ts
@@ -1,23 +1,23 @@
 export function formatGender(genderCode: number | string): string {
   // https://datadictionary.nhs.uk/attributes/person_gender_code.html
-  if (genderCode === 1 || genderCode === '1') {
-    return 'Male'
-  } else if (genderCode === 2 || genderCode === '2') {
-    return 'Female'
-  } else if (genderCode === 9 || genderCode === '9') {
-    return 'Not Specified'
+  if (genderCode === 1 || genderCode === "1") {
+    return "Male";
+  } else if (genderCode === 2 || genderCode === "2") {
+    return "Female";
+  } else if (genderCode === 9 || genderCode === "9") {
+    return "Not Specified";
   } else {
-    return 'Not Known'
+    return "Not Known";
   }
 }
 
 export function formatGenderCharacter(genderCode: number | string): string {
   // https://datadictionary.nhs.uk/attributes/person_gender_code.html
-  if (genderCode === 1 || genderCode === '1') {
-    return '♂'
-  } else if (genderCode === 2 || genderCode === '2') {
-    return '♀'
+  if (genderCode === 1 || genderCode === "1") {
+    return "♂";
+  } else if (genderCode === 2 || genderCode === "2") {
+    return "♀";
   } else {
-    return ''
+    return "";
   }
 }

--- a/helpers/utils/dateUtils.ts
+++ b/helpers/utils/dateUtils.ts
@@ -1,16 +1,16 @@
-import { DateTime } from 'luxon'
+import { DateTime } from "luxon";
 
 export function nowString(addDays: number = 0): string {
-  return DateTime.now().plus({ days: addDays }).toISO()
+  return DateTime.now().plus({ days: addDays }).toISO();
 }
 
 export function formatDate(rawDate: string, t: boolean = true, s: boolean = false): string {
   return DateTime.fromISO(rawDate)
-    .setLocale('en-GB')
-    .toLocaleString(t ? (s ? DateTime.DATETIME_SHORT_WITH_SECONDS : DateTime.DATETIME_SHORT) : DateTime.DATE_SHORT)
+    .setLocale("en-GB")
+    .toLocaleString(t ? (s ? DateTime.DATETIME_SHORT_WITH_SECONDS : DateTime.DATETIME_SHORT) : DateTime.DATE_SHORT);
 }
 
 export interface DateRange {
-  start: string | null
-  end: string | null
+  start: string | null;
+  end: string | null;
 }

--- a/helpers/utils/domUtils.ts
+++ b/helpers/utils/domUtils.ts
@@ -1,13 +1,13 @@
 export function removeElement(el: HTMLElement) {
-  if (typeof el.remove !== 'undefined') el.remove()
-  else el.parentNode?.removeChild(el)
+  if (typeof el.remove !== "undefined") el.remove();
+  else el.parentNode?.removeChild(el);
 }
 
 // add the component w/ the specified props
 export function spawn(id: string, propsData: object, component: any, Vue: any) {
-  const Instance = Vue.extend(component)
+  const Instance = Vue.extend(component);
   return new Instance({
-    el: document.getElementById(id)?.appendChild(document.createElement('div')),
+    el: document.getElementById(id)?.appendChild(document.createElement("div")),
     propsData,
-  })
+  });
 }

--- a/helpers/utils/messageUtils.ts
+++ b/helpers/utils/messageUtils.ts
@@ -1,18 +1,18 @@
-import { Message } from '~/interfaces/messages'
+import { Message } from "~/interfaces/messages";
 
 export function MessageSummary(message: Message): string {
-  if (message.msgStatus === 'STORED') {
-    return 'Stored without error'
+  if (message.msgStatus === "STORED") {
+    return "Stored without error";
   }
-  if (message.msgStatus === 'RECEIVED') {
-    return 'Received without error'
+  if (message.msgStatus === "RECEIVED") {
+    return "Received without error";
   }
-  if (message.msgStatus === 'ERROR' || message.msgStatus === 'RESOLVED') {
+  if (message.msgStatus === "ERROR" || message.msgStatus === "RESOLVED") {
     if (message.error) {
-      return message.error.split('\n')[0]
+      return message.error.split("\n")[0];
     } else {
-      return 'No error message recorded'
+      return "No error message recorded";
     }
   }
-  return 'Unknown message status'
+  return "Unknown message status";
 }

--- a/helpers/utils/mirthUtils.ts
+++ b/helpers/utils/mirthUtils.ts
@@ -1,21 +1,21 @@
-import { ChannelMessage, ConnectorMessage } from '~/interfaces/mirth'
+import { ChannelMessage, ConnectorMessage } from "~/interfaces/mirth";
 
 export function messageHasErrors(message: ChannelMessage): boolean {
   for (const msg of Object.values(message.connectorMessages)) {
     if (msg.errorCode !== 0) {
-      return true
+      return true;
     } else if (msg.metaDataMap?.ERROR) {
-      return true
+      return true;
     }
   }
-  return false
+  return false;
 }
 
 export function connectorMessageError(connectorMessage: ConnectorMessage) {
   if (connectorMessage.metaDataMap?.ERROR) {
-    return connectorMessage.metaDataMap.ERROR
+    return connectorMessage.metaDataMap.ERROR;
   } else if (connectorMessage.errorCode !== 0) {
-    return `Error code ${connectorMessage.errorCode}`
+    return `Error code ${connectorMessage.errorCode}`;
   }
-  return null
+  return null;
 }

--- a/helpers/utils/objectUtils.ts
+++ b/helpers/utils/objectUtils.ts
@@ -1,6 +1,6 @@
 export function isEmptyObject(someObject: Object) {
   if (someObject === null || someObject === undefined) {
-    return true
+    return true;
   }
-  return Object.keys(someObject).length === 0
+  return Object.keys(someObject).length === 0;
 }

--- a/helpers/utils/pathUtils.ts
+++ b/helpers/utils/pathUtils.ts
@@ -1,11 +1,11 @@
-const isAbsoluteURLRegex = /^(?:\w+:)\/\//
+const isAbsoluteURLRegex = /^(?:\w+:)\/\//;
 
 export function urlCompare(url1: string, url2: string) {
-  return url1.replace(/\/$/, '') === url2.replace(/\/$/, '')
+  return url1.replace(/\/$/, "") === url2.replace(/\/$/, "");
 }
 
 export function isAbsolute(url: string) {
-  return isAbsoluteURLRegex.test(url)
+  return isAbsoluteURLRegex.test(url);
 }
 
 /*
@@ -33,67 +33,67 @@ SOFTWARE.
 */
 
 function normalize(strArray: string[]) {
-  const resultArray = []
+  const resultArray = [];
   if (strArray.length === 0) {
-    return ''
+    return "";
   }
 
-  if (typeof strArray[0] !== 'string') {
-    throw new TypeError('Url must be a string. Received ' + strArray[0])
+  if (typeof strArray[0] !== "string") {
+    throw new TypeError("Url must be a string. Received " + strArray[0]);
   }
 
   // If the first part is a plain protocol, we combine it with the next part.
   if (strArray[0].match(/^[^/:]+:\/*$/) && strArray.length > 1) {
-    const first = strArray.shift()
-    strArray[0] = first + strArray[0]
+    const first = strArray.shift();
+    strArray[0] = first + strArray[0];
   }
 
   // There must be two or three slashes in the file protocol, two slashes in anything else.
   if (strArray[0].match(/^file:\/\/\//)) {
-    strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///')
+    strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, "$1:///");
   } else {
-    strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1://')
+    strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, "$1://");
   }
 
   for (let i = 0; i < strArray.length; i++) {
-    let component = strArray[i]
+    let component = strArray[i];
 
-    if (typeof component !== 'string') {
-      throw new TypeError('Url must be a string. Received ' + component)
+    if (typeof component !== "string") {
+      throw new TypeError("Url must be a string. Received " + component);
     }
 
-    if (component === '') {
-      continue
+    if (component === "") {
+      continue;
     }
 
     if (i > 0) {
       // Removing the starting slashes for each component but the first.
-      component = component.replace(/^[/]+/, '')
+      component = component.replace(/^[/]+/, "");
     }
     if (i < strArray.length - 1) {
       // Removing the ending slashes for each component but the last.
-      component = component.replace(/[/]+$/, '')
+      component = component.replace(/[/]+$/, "");
     } else {
       // For the last component we will combine multiple slashes to a single one.
-      component = component.replace(/[/]+$/, '/')
+      component = component.replace(/[/]+$/, "/");
     }
 
-    resultArray.push(component)
+    resultArray.push(component);
   }
-  let str = resultArray.join('/')
+  let str = resultArray.join("/");
   // Each input component is now separated by a single slash except the possible first plain protocol part.
 
   // remove trailing slash before parameters or hash
-  str = str.replace(/\/(\?|&|#[^!])/g, '$1')
+  str = str.replace(/\/(\?|&|#[^!])/g, "$1");
 
   // replace ? in parameters with &
-  const parts = str.split('?')
-  str = parts.shift() + (parts.length > 0 ? '?' : '') + parts.join('&')
+  const parts = str.split("?");
+  str = parts.shift() + (parts.length > 0 ? "?" : "") + parts.join("&");
 
-  return str
+  return str;
 }
 
 export function urljoin(...args: string[]): string {
-  const input = [].slice.call(args)
-  return normalize(input)
+  const input = [].slice.call(args);
+  return normalize(input);
 }

--- a/helpers/utils/queryUtils.ts
+++ b/helpers/utils/queryUtils.ts
@@ -3,18 +3,18 @@ export function singleQuery(query: string | (string | null)[]): string | null {
   // If multiple values are passed as an array,
   // only the zeroth value is returned
   if (Array.isArray(query)) {
-    return query[0]
+    return query[0];
   } else {
-    return query
+    return query;
   }
 }
 
 export function integerQuery(query: string | (string | null)[]): number | null {
-  const queryString = singleQuery(query)
+  const queryString = singleQuery(query);
   if (queryString) {
-    return parseInt(queryString)
+    return parseInt(queryString);
   }
-  return null
+  return null;
 }
 
 export function arrayQuery(query: string | number | (string | number | null)[]): (string | number | null)[] {
@@ -22,8 +22,8 @@ export function arrayQuery(query: string | number | (string | number | null)[]):
   // If a single value is passed,
   // oconvert into a one-element array
   if (!Array.isArray(query)) {
-    return [query]
+    return [query];
   } else {
-    return query
+    return query;
   }
 }

--- a/helpers/utils/recordUtils.ts
+++ b/helpers/utils/recordUtils.ts
@@ -1,78 +1,78 @@
-import { PatientNumber } from '~/interfaces/patient'
-import { PatientRecordSummary } from '~/interfaces/patientrecord'
+import { PatientNumber } from "~/interfaces/patient";
+import { PatientRecordSummary } from "~/interfaces/patientrecord";
 
-const ukrdcMembershipFacilities = ['PV', 'PKB']
-const membershipExtracts = ['RADAR']
-const migratedExtracts = ['PVMIG', 'HSMIG']
+const ukrdcMembershipFacilities = ["PV", "PKB"];
+const membershipExtracts = ["RADAR"];
+const migratedExtracts = ["PVMIG", "HSMIG"];
 
 export interface localNumber {
-  label: string
-  number: string
+  label: string;
+  number: string;
 }
 
 export function isData(record: PatientRecordSummary): boolean {
-  if (record.sendingextract === 'PV') {
-    return true
+  if (record.sendingextract === "PV") {
+    return true;
   }
   if (
-    record.sendingextract === 'UKRDC' &&
+    record.sendingextract === "UKRDC" &&
     !ukrdcMembershipFacilities.includes(record.sendingfacility) &&
-    record.sendingfacility !== 'TRACING'
+    record.sendingfacility !== "TRACING"
   ) {
-    return true
+    return true;
   }
-  return false
+  return false;
 }
 
 export function isSurvey(record: PatientRecordSummary): boolean {
-  if (record.sendingextract === 'SURVEY') {
-    return true
+  if (record.sendingextract === "SURVEY") {
+    return true;
   }
-  return false
+  return false;
 }
 
 export function isMigrated(record: PatientRecordSummary) {
   if (migratedExtracts.includes(record.sendingextract)) {
-    return true
+    return true;
   }
-  return false
+  return false;
 }
 
 export function isMembership(record: PatientRecordSummary) {
   if (membershipExtracts.includes(record.sendingextract)) {
-    return true
+    return true;
   }
-  if (record.sendingextract === 'UKRDC' && ukrdcMembershipFacilities.includes(record.sendingfacility)) {
-    return true
+  if (record.sendingextract === "UKRDC" && ukrdcMembershipFacilities.includes(record.sendingfacility)) {
+    return true;
   }
-  return false
+  return false;
 }
 
 export function isTracing(record: PatientRecordSummary) {
-  if (record.sendingextract === 'UKRDC' && record.sendingfacility === 'TRACING') {
-    return true
+  if (record.sendingextract === "UKRDC" && record.sendingfacility === "TRACING") {
+    return true;
   }
-  return false
+  return false;
 }
 
 export function firstForename(record: PatientRecordSummary): string {
-  return record.patient.names[0]?.given || ''
+  return record.patient.names[0]?.given || "";
 }
 
 export function firstSurname(record: PatientRecordSummary): string {
-  return record.patient.names[0]?.family || ''
+  return record.patient.names[0]?.family || "";
 }
 
 export function firstMRN(record: PatientRecordSummary): localNumber {
-  const mrn = record.patient.numbers.find((i: PatientNumber) => i.numbertype === 'MRN')
+  const mrn = record.patient.numbers.find((i: PatientNumber) => i.numbertype === "MRN");
   if (mrn) {
     return {
-      label: mrn.organization === 'LOCALHOSP' ? 'Hospital' : mrn.organization,
+      label: mrn.organization === "LOCALHOSP" ? "Hospital" : mrn.organization,
       number: mrn.patientid,
-    }
+    };
   }
   return {
-    label: '',
-    number: '',
-  }
+    label: "",
+    number: "",
+  };
 }

--- a/helpers/utils/timeUtils.ts
+++ b/helpers/utils/timeUtils.ts
@@ -1,3 +1,3 @@
 export function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/helpers/utils/workItemUtils.ts
+++ b/helpers/utils/workItemUtils.ts
@@ -37,36 +37,36 @@ by the same event, which can be resolved without the others.
 
 */
 
-import { WorkItem, WorkItemExtended } from '~/interfaces/workitem'
+import { WorkItem, WorkItemExtended } from "~/interfaces/workitem";
 
 export function workItemIsOpen(item: WorkItem): Boolean {
-  return item?.status !== 3
+  return item?.status !== 3;
 }
 
 export function workItemIsUKRDC(item: WorkItem) {
-  return item?.type === 3 || item?.type === 6
+  return item?.type === 3 || item?.type === 6;
 }
 
 export function workItemIsMergable(item: WorkItemExtended): Boolean {
   // Check if a workitem can be merged (incoming and destination UKRDC records)
-  return workItemIsUKRDC(item) && item.incoming.masterRecords.length > 0 && !!item.destination.masterRecord
+  return workItemIsUKRDC(item) && item.incoming.masterRecords.length > 0 && !!item.destination.masterRecord;
 }
 
 export function workItemIsSecondary(item: WorkItemExtended, related: WorkItem[]) {
   // Check if a workitem should be treated as secondary to others in the collection
   if (workItemIsMergable(item)) {
     // Mergable workitems are always "primary"
-    return false
+    return false;
   }
   // For each related Work Item in the collection
   for (const relatedItem of related) {
     // If the related Work Item is a mergable UKRDC Work Item
     if (workItemIsUKRDC(relatedItem) && workItemIsOpen(relatedItem)) {
-      return true
+      return true;
     }
   }
   // If no items in the collection need to be resolved, this is a "primary" workitem
-  return false
+  return false;
 }
 
 export function collectionIsUnresolved(related: WorkItem[]) {
@@ -74,17 +74,17 @@ export function collectionIsUnresolved(related: WorkItem[]) {
   for (const relatedItem of related) {
     // If the related Work Item is a mergable UKRDC Work Item
     if (workItemIsOpen(relatedItem)) {
-      return true
+      return true;
     }
   }
-  return false
+  return false;
 }
 
 export function formatAttributeValue(attributeString: String) {
-  const splitString = attributeString.split(':')
+  const splitString = attributeString.split(":");
   if (splitString.length > 1) {
-    return `${attributeString.split(':')[1]} → ${attributeString.split(':')[0]}`
+    return `${attributeString.split(":")[1]} → ${attributeString.split(":")[0]}`;
   } else {
-    return attributeString.split(':')[0]
+    return attributeString.split(":")[0];
   }
 }

--- a/interfaces/admin.ts
+++ b/interfaces/admin.ts
@@ -1,9 +1,9 @@
 export interface AdminCounts {
-  openWorkitems: number
-  UKRDCRecords: number
-  patientsReceivingErrors: number
+  openWorkitems: number;
+  UKRDCRecords: number;
+  patientsReceivingErrors: number;
 }
 
 export interface LastRunTime {
-  lastRunTime: string
+  lastRunTime: string;
 }

--- a/interfaces/audit.ts
+++ b/interfaces/audit.ts
@@ -1,26 +1,26 @@
 interface AccessEvent {
-  id: number
-  time: string
+  id: number;
+  time: string;
 
-  userId: string
-  clientId: string
-  userEmail: string
+  userId: string;
+  clientId: string;
+  userEmail: string;
 
-  path: string
-  method: string
-  body: string
+  path: string;
+  method: string;
+  body: string;
 }
 
 export interface AuditEvent {
-  id: number
-  accessEvent: AccessEvent
+  id: number;
+  accessEvent: AccessEvent;
 
-  resource: string
-  resourceId: string
+  resource: string;
+  resourceId: string;
 
-  operation: string
+  operation: string;
 
-  children: AuditEvent[]
+  children: AuditEvent[];
 
-  identifiers: string[]
+  identifiers: string[];
 }

--- a/interfaces/charts.ts
+++ b/interfaces/charts.ts
@@ -1,4 +1,4 @@
 export interface HistoryPointEvent {
-  x: number
-  y: number
+  x: number;
+  y: number;
 }

--- a/interfaces/codes.ts
+++ b/interfaces/codes.ts
@@ -1,23 +1,23 @@
 export interface Code {
-  codingStandard: string
-  code: string
-  description: string
-  objectType: string
-  creationDate: string
-  updateDate: string
-  units: string
+  codingStandard: string;
+  code: string;
+  description: string;
+  objectType: string;
+  creationDate: string;
+  updateDate: string;
+  units: string;
 }
 
 export interface CodeMap {
-  sourceCodingStandard: string
-  sourceCode: string
-  destinationCodingStandard: string
-  destinationCode: string
-  creationDate: string
-  updateDate: string
+  sourceCodingStandard: string;
+  sourceCode: string;
+  destinationCodingStandard: string;
+  destinationCode: string;
+  creationDate: string;
+  updateDate: string;
 }
 
 export interface ExtendedCode extends Code {
-  mapsTo: CodeMap[]
-  mappedBy: CodeMap[]
+  mapsTo: CodeMap[];
+  mappedBy: CodeMap[];
 }

--- a/interfaces/common.ts
+++ b/interfaces/common.ts
@@ -1,4 +1,4 @@
 export interface HistoryItem {
-  time: string
-  count: number
+  time: string;
+  count: number;
 }

--- a/interfaces/dash.ts
+++ b/interfaces/dash.ts
@@ -1,16 +1,16 @@
 export interface DashResponse {
-  messages: string[]
-  warnings: string[]
+  messages: string[];
+  warnings: string[];
 }
 
 export interface ChannelStatistics {
-  name: string
-  updated: string
-  serverId: string
-  channelId: string
-  received: number
-  sent: number
-  error: number
-  filtered: number
-  queued: number
+  name: string;
+  updated: string;
+  serverId: string;
+  channelId: string;
+  received: number;
+  sent: number;
+  error: number;
+  filtered: number;
+  queued: number;
 }

--- a/interfaces/datahealth.ts
+++ b/interfaces/datahealth.ts
@@ -1,18 +1,18 @@
-import { MasterRecord } from './masterrecord'
+import { MasterRecord } from "./masterrecord";
 
 interface MultipleUKRDCIDsGroupItem {
-  lastUpdated: string | null
-  masterRecord: MasterRecord
+  lastUpdated: string | null;
+  masterRecord: MasterRecord;
 }
 
 export interface MultipleUKRDCIDsGroup {
-  groupId: number | null
-  records: MultipleUKRDCIDsGroupItem[]
+  groupId: number | null;
+  records: MultipleUKRDCIDsGroupItem[];
 }
 
 export interface MultipleUKRDCIDsPage {
-  items: MultipleUKRDCIDsGroup[]
-  total: number
-  page: number
-  size: number
+  items: MultipleUKRDCIDsGroup[];
+  total: number;
+  page: number;
+  size: number;
 }

--- a/interfaces/document.ts
+++ b/interfaces/document.ts
@@ -1,52 +1,52 @@
 interface PatientDocumentLinks {
-  self: string
-  download: string
+  self: string;
+  download: string;
 }
 
 export interface PatientDocumentSummary {
-  id: string
-  pid: string
+  id: string;
+  pid: string;
 
-  documenttime: string
-  documentname: string
+  documenttime: string;
+  documentname: string;
 
-  filename: string
-  filetype: string
+  filename: string;
+  filetype: string;
 
-  enteredbydesc: string
-  enteredatcode: string
+  enteredbydesc: string;
+  enteredatcode: string;
 
-  links: PatientDocumentLinks
+  links: PatientDocumentLinks;
 }
 
 export interface PatientDocument extends PatientDocumentSummary {
-  idx: number
+  idx: number;
 
-  notetext: string
-  documenttypecode: string
-  documenttypecodestd: string
-  documenttypedesc: string
+  notetext: string;
+  documenttypecode: string;
+  documenttypecodestd: string;
+  documenttypedesc: string;
 
-  cliniciancode: string
-  cliniciancodestd: string
-  cliniciandesc: string
+  cliniciancode: string;
+  cliniciancodestd: string;
+  cliniciandesc: string;
 
-  statuscode: string
-  statuscodestd: string
-  statusdesc: string
-  enteredbycode: string
-  enteredbycodestd: string
+  statuscode: string;
+  statuscodestd: string;
+  statusdesc: string;
+  enteredbycode: string;
+  enteredbycodestd: string;
 
-  enteredatcodestd: string
-  enteredatdesc: string
+  enteredatcodestd: string;
+  enteredatdesc: string;
 
-  documenturl: string
-  updatedon: string
-  actioncode: string
-  externalid: string
+  documenturl: string;
+  updatedon: string;
+  actioncode: string;
+  externalid: string;
 
-  updateDate: string
-  creationDate: string
+  updateDate: string;
+  creationDate: string;
 
-  repositoryUpdateDate: string
+  repositoryUpdateDate: string;
 }

--- a/interfaces/facilities.ts
+++ b/interfaces/facilities.ts
@@ -1,28 +1,28 @@
 interface FacilityLinks {
-  self: string
-  errorsHistory: string
-  patientsLatestErrors: string
+  self: string;
+  errorsHistory: string;
+  patientsLatestErrors: string;
 }
 
 export interface FacilityStatistics {
-  lastUpdated: string
-  totalPatients: number
-  patientsReceivingMessages: number
-  patientsReceivingMessageSuccess: number
-  patientsReceivingMessageError: number
+  lastUpdated: string;
+  totalPatients: number;
+  patientsReceivingMessages: number;
+  patientsReceivingMessageSuccess: number;
+  patientsReceivingMessageError: number;
 }
 
 interface FacilityDataFlowSchema {
-  pkbIn: boolean
-  pkbOut: boolean
-  pkbMessageExclusions: string[]
+  pkbIn: boolean;
+  pkbOut: boolean;
+  pkbMessageExclusions: string[];
 }
 
 export interface Facility {
-  id: string
-  description: string
-  statistics: FacilityStatistics
-  dataFlow: FacilityDataFlowSchema
+  id: string;
+  description: string;
+  statistics: FacilityStatistics;
+  dataFlow: FacilityDataFlowSchema;
 
-  links: FacilityLinks
+  links: FacilityLinks;
 }

--- a/interfaces/laborder.ts
+++ b/interfaces/laborder.ts
@@ -1,29 +1,29 @@
 interface LabOrderLinks {
-  self: string
+  self: string;
 }
 
 interface ResultItemLinks {
-  self: string
+  self: string;
 }
 
 export interface LabOrderShort {
-  id: string
-  enteredAt: string
-  enteredAtDescription: string
-  specimenCollectedTime: string
-  links: LabOrderLinks
+  id: string;
+  enteredAt: string;
+  enteredAtDescription: string;
+  specimenCollectedTime: string;
+  links: LabOrderLinks;
 }
 
 export interface ResultItem {
-  id: string
-  orderId: string
-  serviceId: string
-  serviceIdDescription: string
-  value: string
-  valueUnits: string
-  links: ResultItemLinks
+  id: string;
+  orderId: string;
+  serviceId: string;
+  serviceIdDescription: string;
+  value: string;
+  valueUnits: string;
+  links: ResultItemLinks;
 }
 
 export interface LabOrder extends LabOrderShort {
-  resultItems: ResultItem[]
+  resultItems: ResultItem[];
 }

--- a/interfaces/linkrecords.ts
+++ b/interfaces/linkrecords.ts
@@ -1,14 +1,14 @@
-import { Person } from '@/interfaces/persons'
-import { MasterRecord } from '@/interfaces/masterrecord'
+import { Person } from "@/interfaces/persons";
+import { MasterRecord } from "@/interfaces/masterrecord";
 
 export interface LinkRecord {
-  id: number
-  person: Person
-  masterRecord: MasterRecord
+  id: number;
+  person: Person;
+  masterRecord: MasterRecord;
 }
 
 export interface LinkRecordSummary {
-  id: number
-  personId: number
-  masterId: number
+  id: number;
+  personId: number;
+  masterId: number;
 }

--- a/interfaces/masterrecord.ts
+++ b/interfaces/masterrecord.ts
@@ -1,33 +1,33 @@
 interface MasterRecordLinks {
-  self: string
-  latestMessage: string
-  statistics: string
-  related: string
-  messages: string
-  errors: string
-  linkrecords: string
-  persons: string
-  workitems: string
-  patientrecords: string
-  audit: string
+  self: string;
+  latestMessage: string;
+  statistics: string;
+  related: string;
+  messages: string;
+  errors: string;
+  linkrecords: string;
+  persons: string;
+  workitems: string;
+  patientrecords: string;
+  audit: string;
 }
 
 export interface MasterRecordStatistics {
-  workitems: number
-  errors: number
-  ukrdcids: number
+  workitems: number;
+  errors: number;
+  ukrdcids: number;
 }
 
 export interface MasterRecord {
-  id: number
-  nationalid: string
-  nationalidType: string
-  lastUpdated: string
-  dateOfBirth: string
-  gender: string
-  givenname: string
-  surname: string
-  status: number
-  effectiveDate: string
-  links: MasterRecordLinks
+  id: number;
+  nationalid: string;
+  nationalidType: string;
+  lastUpdated: string;
+  dateOfBirth: string;
+  gender: string;
+  givenname: string;
+  surname: string;
+  status: number;
+  effectiveDate: string;
+  links: MasterRecordLinks;
 }

--- a/interfaces/medication.ts
+++ b/interfaces/medication.ts
@@ -1,8 +1,8 @@
 export interface Medication {
-  fromTime: string
-  toTime: string
-  drugProductGeneric: string
-  comment: string
-  enteringOrganizationCode: string
-  enteringOrganizationDescription: string
+  fromTime: string;
+  toTime: string;
+  drugProductGeneric: string;
+  comment: string;
+  enteringOrganizationCode: string;
+  enteringOrganizationDescription: string;
 }

--- a/interfaces/messages.ts
+++ b/interfaces/messages.ts
@@ -1,30 +1,30 @@
 interface MessageLinks {
-  self: string
-  mirth: string
-  workitems: string
-  masterrecords: string
-  source: string
+  self: string;
+  mirth: string;
+  workitems: string;
+  masterrecords: string;
+  source: string;
 }
 
 export interface MinimalMessage {
-  id: string
-  received: string
-  msgStatus: string
-  ni: string
-  filename: string
-  facility: string
+  id: string;
+  received: string;
+  msgStatus: string;
+  ni: string;
+  filename: string;
+  facility: string;
 }
 export interface Message extends MinimalMessage {
-  messageId: number
-  channelId: string
-  channel: string
-  error: string
-  status: string
-  msgStatus: string
-  links: MessageLinks
+  messageId: number;
+  channelId: string;
+  channel: string;
+  error: string;
+  status: string;
+  msgStatus: string;
+  links: MessageLinks;
 }
 
 export interface ErrorSource {
-  content: string
-  contentType: string
+  content: string;
+  contentType: string;
 }

--- a/interfaces/mirth.ts
+++ b/interfaces/mirth.ts
@@ -1,85 +1,85 @@
 interface ChannelMessageLinks {
-  self: string
+  self: string;
 }
 
 export interface ConnectorMessageData {
-  channelId: string
-  content: string
-  contentType: string
-  dataType: string
-  encrypted: boolean
-  messageId: string
-  messageDataId: string
+  channelId: string;
+  content: string;
+  contentType: string;
+  dataType: string;
+  encrypted: boolean;
+  messageId: string;
+  messageDataId: string;
 }
 
 export interface MetaDataMap {
-  [key: string]: string
+  [key: string]: string;
 }
 
 export interface ConnectorMessage {
-  chainId: number
-  orderId: number
-  serverId: string
-  channelId: string
-  channelName: string
-  connectorName: string
+  chainId: number;
+  orderId: number;
+  serverId: string;
+  channelId: string;
+  channelName: string;
+  connectorName: string;
 
-  messageId: string
-  errorCode: number
-  sendAttempts: number
+  messageId: string;
+  errorCode: number;
+  sendAttempts: number;
 
-  raw: ConnectorMessageData
-  encoded: ConnectorMessageData
-  sent: ConnectorMessageData
-  response: ConnectorMessageData
+  raw: ConnectorMessageData;
+  encoded: ConnectorMessageData;
+  sent: ConnectorMessageData;
+  response: ConnectorMessageData;
 
-  metaDataMap: MetaDataMap
+  metaDataMap: MetaDataMap;
 }
 
 export interface connectorMessagesMap {
-  [key: number]: ConnectorMessage
+  [key: number]: ConnectorMessage;
 }
 
 export interface ChannelMessage {
-  messageId: number
-  serverId: string
-  channelId: string
-  processed: boolean
+  messageId: number;
+  serverId: string;
+  channelId: string;
+  processed: boolean;
 
-  connectorMessages: { [key: number]: ConnectorMessage }
+  connectorMessages: { [key: number]: ConnectorMessage };
 
-  links: ChannelMessageLinks
+  links: ChannelMessageLinks;
 }
 
 export interface MirthMessageResponse {
-  status: string
-  message: string
+  status: string;
+  message: string;
 }
 
 export interface ChannelStatistics {
-  received: number
-  sent: number
-  error: number
-  filtered: number
-  queued: number
+  received: number;
+  sent: number;
+  error: number;
+  filtered: number;
+  queued: number;
 }
 
 export interface Channel {
-  id: string
-  name: string
-  description: string
-  revision: string
-  statistics: ChannelStatistics
+  id: string;
+  name: string;
+  description: string;
+  revision: string;
+  statistics: ChannelStatistics;
 }
 
 export interface ChannelGroup {
-  id: string
-  name: string
-  description: string
-  revision: string
-  channels: Channel[]
+  id: string;
+  name: string;
+  description: string;
+  revision: string;
+  channels: Channel[];
 }
 
 export interface ChainMap {
-  [key: number]: ConnectorMessage[]
+  [key: number]: ConnectorMessage[];
 }

--- a/interfaces/modal.ts
+++ b/interfaces/modal.ts
@@ -1,8 +1,8 @@
-import Vue from 'vue'
+import Vue from "vue";
 
 export interface modalInterface extends Vue {
-  show: () => void
-  hide: () => void
-  toggle: () => void
-  visible: boolean
+  show: () => void;
+  hide: () => void;
+  toggle: () => void;
+  visible: boolean;
 }

--- a/interfaces/observation.ts
+++ b/interfaces/observation.ts
@@ -1,9 +1,9 @@
 export interface Observation {
-  observationTime: string
-  observationDesc: string
-  observationValue: string
-  observationUnits: string
-  prePost: string
-  enteredAt: string
-  enteredAtDescription: string
+  observationTime: string;
+  observationDesc: string;
+  observationValue: string;
+  observationUnits: string;
+  prePost: string;
+  enteredAt: string;
+  enteredAtDescription: string;
 }

--- a/interfaces/pagination.ts
+++ b/interfaces/pagination.ts
@@ -1,4 +1,4 @@
 export interface PaginationQuery {
-  page: number
-  size: number
+  page: number;
+  size: number;
 }

--- a/interfaces/patient.ts
+++ b/interfaces/patient.ts
@@ -1,76 +1,76 @@
 export interface PatientName {
-  given: string
-  family: string
+  given: string;
+  family: string;
 }
 
 export interface PatientNumber {
-  patientid: string
-  organization: string
-  numbertype: string
+  patientid: string;
+  organization: string;
+  numbertype: string;
 }
 
 interface PatientAddress {
-  fromTime: string
-  toTime: string
-  street: string
-  town: string
-  county: string
-  postcode: string
-  countryDescription: string
+  fromTime: string;
+  toTime: string;
+  street: string;
+  town: string;
+  county: string;
+  postcode: string;
+  countryDescription: string;
 }
 
 interface ContactDetails {
-  use: string
-  value: string
-  commenttext: string
+  use: string;
+  value: string;
+  commenttext: string;
 }
 
 interface GPInfo {
-  code: string
-  gpname: string
-  street: string
-  postcode: string
-  contactvalue: string
-  type: string
+  code: string;
+  gpname: string;
+  street: string;
+  postcode: string;
+  contactvalue: string;
+  type: string;
 }
 
 interface FamilyDoctor {
-  id: string
-  gpname: string
+  id: string;
+  gpname: string;
 
-  gpid: string
-  gpInfo: GPInfo
+  gpid: string;
+  gpInfo: GPInfo;
 
-  gppracticeid: string
-  gpPracticeInfo: GPInfo
+  gppracticeid: string;
+  gpPracticeInfo: GPInfo;
 
-  addressuse: string
-  fromtime: string
-  totime: string
-  town: string
-  county: string
-  postcode: string
-  countrycode: string
-  countrycodestd: string
-  countrydesc: string
-  contactuse: string
-  contactvalue: string
-  email: string
-  commenttext: string
+  addressuse: string;
+  fromtime: string;
+  totime: string;
+  town: string;
+  county: string;
+  postcode: string;
+  countrycode: string;
+  countrycodestd: string;
+  countrydesc: string;
+  contactuse: string;
+  contactvalue: string;
+  email: string;
+  commenttext: string;
 }
 
 export interface Patient {
-  names: PatientName[]
-  numbers: PatientNumber[]
-  addresses: PatientAddress[]
-  contactdetails: ContactDetails[]
+  names: PatientName[];
+  numbers: PatientNumber[];
+  addresses: PatientAddress[];
+  contactdetails: ContactDetails[];
 
-  familydoctor: FamilyDoctor
+  familydoctor: FamilyDoctor;
 
-  birthTime: string
-  deathTime: string
-  gender: string
+  birthTime: string;
+  deathTime: string;
+  gender: string;
 
-  ethnicGroupDescription: string
-  ethnicGroupCode: string
+  ethnicGroupDescription: string;
+  ethnicGroupCode: string;
 }

--- a/interfaces/patientrecord.ts
+++ b/interfaces/patientrecord.ts
@@ -1,117 +1,117 @@
-import { Medication } from './medication'
-import { Observation } from './observation'
-import { Survey } from './survey'
-import { MasterRecord } from './masterrecord'
-import { Patient } from '@/interfaces/patient'
-import { PatientDocument } from '@/interfaces/document'
+import { Medication } from "./medication";
+import { Observation } from "./observation";
+import { Survey } from "./survey";
+import { MasterRecord } from "./masterrecord";
+import { Patient } from "@/interfaces/patient";
+import { PatientDocument } from "@/interfaces/document";
 
 interface ProgramMembership {
-  programName: string
-  fromTime: string
-  toTime: string
+  programName: string;
+  fromTime: string;
+  toTime: string;
 }
 
 interface PatientRecordLinks {
-  self: string
-  related: string
-  delete: string
+  self: string;
+  related: string;
+  delete: string;
 
-  medications: string
-  treatments: string
-  surveys: string
-  documents: string
+  medications: string;
+  treatments: string;
+  surveys: string;
+  documents: string;
 
-  observations: string
-  observationCodes: string
+  observations: string;
+  observationCodes: string;
 
-  results: string
-  resultServices: string
+  results: string;
+  resultServices: string;
 
-  laborders: string
+  laborders: string;
 
-  exportPV: string
-  exportPVDocs: string
-  exportPVTests: string
-  exportRADAR: string
+  exportPV: string;
+  exportPVDocs: string;
+  exportPVTests: string;
+  exportRADAR: string;
 }
 
 export interface PatientRecordSummary {
-  pid: string
-  sendingfacility: string
-  sendingextract: string
-  localpatientid: string
-  ukrdcid: string
-  repositoryCreationDate: string
-  repositoryUpdateDate: string
-  programMemberships: ProgramMembership[]
-  patient: Patient
+  pid: string;
+  sendingfacility: string;
+  sendingextract: string;
+  localpatientid: string;
+  ukrdcid: string;
+  repositoryCreationDate: string;
+  repositoryUpdateDate: string;
+  programMemberships: ProgramMembership[];
+  patient: Patient;
 
-  links: PatientRecordLinks
+  links: PatientRecordLinks;
 }
 
 export interface PatientRecord extends PatientRecordSummary {
-  masterRecord: MasterRecord
+  masterRecord: MasterRecord;
 }
 
 interface idPidInterface {
-  id: string
-  pid: string
+  id: string;
+  pid: string;
 }
 
 interface Diagnosis {
-  id: string
-  pid: string
+  id: string;
+  pid: string;
 
-  diagnosisCode: string
-  diagnosisCodeStd: string
-  diagnosisDesc: string
+  diagnosisCode: string;
+  diagnosisCodeStd: string;
+  diagnosisDesc: string;
 
-  identificationTime: string
-  onsetTime: string
+  identificationTime: string;
+  onsetTime: string;
 
-  comments: string
+  comments: string;
 }
 
 interface RenalDiagnosis {
-  pid: string
+  pid: string;
 
-  diagnosisCode: string
-  diagnosisCodeStd: string
-  diagnosisDesc: string
+  diagnosisCode: string;
+  diagnosisCodeStd: string;
+  diagnosisDesc: string;
 
-  identificationTime: string
+  identificationTime: string;
 
-  comments: string
+  comments: string;
 }
 
 interface Encounter {
-  id: string
-  pid: string
+  id: string;
+  pid: string;
 
-  fromTime: string
-  toTime: string
+  fromTime: string;
+  toTime: string;
 }
 
 interface PVDelete {
-  did: number
-  pid: string
-  observationTime: string
-  serviceId: string
+  did: number;
+  pid: string;
+  observationTime: string;
+  serviceId: string;
 }
 
 export interface PatientRecordFull extends PatientRecordSummary {
-  socialHistories: idPidInterface[]
-  familyHistories: idPidInterface[]
-  observations: Observation[]
-  allergies: idPidInterface[]
-  diagnoses: Diagnosis[]
-  renaldiagnoses: RenalDiagnosis[]
-  medications: Medication[]
-  procedures: idPidInterface[]
-  documents: PatientDocument[]
-  encounters: Encounter[]
-  programMemberships: ProgramMembership[]
-  clinicalRelationships: idPidInterface[]
-  surveys: Survey[]
-  pvdelete: PVDelete[]
+  socialHistories: idPidInterface[];
+  familyHistories: idPidInterface[];
+  observations: Observation[];
+  allergies: idPidInterface[];
+  diagnoses: Diagnosis[];
+  renaldiagnoses: RenalDiagnosis[];
+  medications: Medication[];
+  procedures: idPidInterface[];
+  documents: PatientDocument[];
+  encounters: Encounter[];
+  programMemberships: ProgramMembership[];
+  clinicalRelationships: idPidInterface[];
+  surveys: Survey[];
+  pvdelete: PVDelete[];
 }

--- a/interfaces/persons.ts
+++ b/interfaces/persons.ts
@@ -1,27 +1,27 @@
 export interface PidXRef {
-  id: number
-  pid: string
-  sendingFacility: string
-  sendingExtract: string
-  localid: string
+  id: number;
+  pid: string;
+  sendingFacility: string;
+  sendingExtract: string;
+  localid: string;
 }
 
 interface PersonLinks {
-  self: string
-  patientrecord: string
-  masterrecords: string
+  self: string;
+  patientrecord: string;
+  masterrecords: string;
 }
 
 export interface Person {
-  id: number
-  originator: string
-  localid: string
-  localidType: string
-  dateOfBirth: string
-  gender: string
-  dateOfDeath: string
-  givenname: string
-  surname: string
-  xrefEntries: PidXRef[]
-  links: PersonLinks
+  id: number;
+  originator: string;
+  localid: string;
+  localidType: string;
+  dateOfBirth: string;
+  gender: string;
+  dateOfDeath: string;
+  givenname: string;
+  surname: string;
+  xrefEntries: PidXRef[];
+  links: PersonLinks;
 }

--- a/interfaces/survey.ts
+++ b/interfaces/survey.ts
@@ -1,34 +1,34 @@
 export interface SurveyQuestion {
-  id: string
-  questiontypecode: string
-  response: string
+  id: string;
+  questiontypecode: string;
+  response: string;
 
-  questionGroup: string
-  questionType: string
-  responseText: string
+  questionGroup: string;
+  questionType: string;
+  responseText: string;
 }
 
 export interface SurveyScore {
-  id: string
-  value: string
-  scoretypecode: string
+  id: string;
+  value: string;
+  scoretypecode: string;
 }
 
 export interface SurveyLevel {
-  id: string
-  value: string
-  leveltypecode: string
+  id: string;
+  value: string;
+  leveltypecode: string;
 }
 
 export interface Survey {
-  id: string
-  pid: string
-  surveytime: string
-  surveytypecode: string
-  enteredbycode: string
-  enteredatcode: string
+  id: string;
+  pid: string;
+  surveytime: string;
+  surveytypecode: string;
+  enteredbycode: string;
+  enteredatcode: string;
 
-  questions: SurveyQuestion[]
-  scores: SurveyScore[]
-  levels: SurveyLevel[]
+  questions: SurveyQuestion[];
+  scores: SurveyScore[];
+  levels: SurveyLevel[];
 }

--- a/interfaces/tabs.ts
+++ b/interfaces/tabs.ts
@@ -1,4 +1,4 @@
 export interface TabItem {
-  name: string
-  href: string
+  name: string;
+  href: string;
 }

--- a/interfaces/treatment.ts
+++ b/interfaces/treatment.ts
@@ -1,16 +1,16 @@
 export interface Treatment {
-  id: string
+  id: string;
 
-  fromTime: string
-  toTime: string
+  fromTime: string;
+  toTime: string;
 
-  admitReasonCode: string
-  admitReasonCodeStd: string
-  admitReasonDesc: string
+  admitReasonCode: string;
+  admitReasonCodeStd: string;
+  admitReasonDesc: string;
 
-  dischargeReasonCode: string
-  dischargeReasonCodeStd: string
-  dischargeReasonDesc: string
+  dischargeReasonCode: string;
+  dischargeReasonCodeStd: string;
+  dischargeReasonDesc: string;
 
-  healthCareFacilityCode: string
+  healthCareFacilityCode: string;
 }

--- a/interfaces/user.ts
+++ b/interfaces/user.ts
@@ -1,4 +1,4 @@
 export interface UserInfo {
-  email?: string
-  permissions: string[]
+  email?: string;
+  permissions: string[];
 }

--- a/interfaces/workitem.ts
+++ b/interfaces/workitem.ts
@@ -1,60 +1,60 @@
-import { Person } from '@/interfaces/persons'
-import { MasterRecord } from '@/interfaces/masterrecord'
+import { Person } from "@/interfaces/persons";
+import { MasterRecord } from "@/interfaces/masterrecord";
 
 interface WorkItemLinks {
-  self: string
-  collection: string
-  related: string
-  messages: string
-  merge: string
-  close: string
-  unlink: string
+  self: string;
+  collection: string;
+  related: string;
+  messages: string;
+  merge: string;
+  close: string;
+  unlink: string;
 }
 
 export interface WorkItemAttributes {
-  sendingExtract: string
-  sendingFacility: string
-  localid: string
-  dateOfBirth: string
-  dateOfDeath: string
-  gender: string
-  givenname: string
-  surname: string
+  sendingExtract: string;
+  sendingFacility: string;
+  localid: string;
+  dateOfBirth: string;
+  dateOfDeath: string;
+  gender: string;
+  givenname: string;
+  surname: string;
 }
 
 export interface WorkItem {
-  id: number
+  id: number;
 
-  type: number
-  description: string
-  status: number
+  type: number;
+  description: string;
+  status: number;
 
-  creationDate: string
+  creationDate: string;
 
-  lastUpdated: string
-  updatedBy: string
-  updateDescription: string
+  lastUpdated: string;
+  updatedBy: string;
+  updateDescription: string;
 
-  attributes: WorkItemAttributes
+  attributes: WorkItemAttributes;
 
-  masterRecord: MasterRecord
-  person: Person
+  masterRecord: MasterRecord;
+  person: Person;
 
-  links: WorkItemLinks
+  links: WorkItemLinks;
 }
 
 interface WorkItemIncoming {
-  person: Person
-  masterRecords: MasterRecord[]
+  person: Person;
+  masterRecords: MasterRecord[];
 }
 
 interface WorkItemDestination {
-  persons: Person[]
-  masterRecord: MasterRecord
+  persons: Person[];
+  masterRecord: MasterRecord;
 }
 
 export interface WorkItemExtended extends WorkItem {
-  incoming: WorkItemIncoming
-  destination: WorkItemDestination
-  collection: WorkItem[]
+  incoming: WorkItemIncoming;
+  destination: WorkItemDestination;
+  collection: WorkItem[];
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -66,7 +66,7 @@
         <!-- Sidebar menu button -->
         <div class="justify-left inline-flex flex-grow items-center">
           <button
-            class="focus:outline-none -ml-0.5 -mt-0.5 inline-flex h-12 w-12 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+            class="-ml-0.5 -mt-0.5 inline-flex h-12 w-12 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
             @click="toggle()"
           >
             <span class="sr-only">Open sidebar</span>
@@ -90,7 +90,7 @@
       </div>
 
       <!-- Main page content -->
-      <main class="focus:outline-none relative z-0 flex-1 overflow-y-auto" tabindex="0">
+      <main class="relative z-0 flex-1 overflow-y-auto focus:outline-none" tabindex="0">
         <Nuxt class="mx-auto max-w-7xl py-6 px-4 sm:px-6 md:px-8" />
       </main>
     </div>
@@ -98,25 +98,25 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, useContext, useMeta } from '@nuxtjs/composition-api'
-import 'v-tooltip/dist/v-tooltip.css'
+import { defineComponent, ref, useContext, useMeta } from "@nuxtjs/composition-api";
+import "v-tooltip/dist/v-tooltip.css";
 
 export default defineComponent({
   setup() {
-    const { base } = useContext()
-    const { link } = useMeta()
-    link.value = [{ rel: 'icon', type: 'image/x-icon', href: `${base || '/'}favicon.ico` }]
+    const { base } = useContext();
+    const { link } = useMeta();
+    link.value = [{ rel: "icon", type: "image/x-icon", href: `${base || "/"}favicon.ico` }];
 
-    const sbOpen = ref(false)
+    const sbOpen = ref(false);
 
     function toggle() {
-      sbOpen.value = !sbOpen.value
+      sbOpen.value = !sbOpen.value;
     }
 
-    return { sbOpen, toggle }
+    return { sbOpen, toggle };
   },
   head: {},
-})
+});
 </script>
 
 <style lang="postcss">

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex h-full flex-col items-center justify-center">
     <div class="block items-center justify-center sm:flex">
-      <TextHcxl class="sm:mr-8">{{ error.statusCode || 'Error' }}</TextHcxl>
+      <TextHcxl class="sm:mr-8">{{ error.statusCode || "Error" }}</TextHcxl>
       <div class="sm:border-l sm:pl-8">
         <TextH1 class="whitespace-pre">{{ errorTitle }}</TextH1>
         <NuxtLink to="/">Home page</NuxtLink>
@@ -14,11 +14,11 @@
 </template>
 
 <script lang="ts">
-import { NuxtError } from '@nuxt/types'
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { NuxtError } from "@nuxt/types";
+import { computed, defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
-  layout: 'error',
+  layout: "error",
   props: {
     error: {
       type: Object as () => NuxtError,
@@ -27,14 +27,14 @@ export default defineComponent({
   },
   setup(props) {
     const errorTitle = computed(() => {
-      return props.error.message?.split('\n')[0] || 'Unknown error'
-    })
+      return props.error.message?.split("\n")[0] || "Unknown error";
+    });
 
     const errorDetail = computed(() => {
-      return props.error.message?.split('\n').slice(1).join('\n') || ''
-    })
+      return props.error.message?.split("\n").slice(1).join("\n") || "";
+    });
 
-    return { errorTitle, errorDetail }
+    return { errorTitle, errorDetail };
   },
-})
+});
 </script>

--- a/middleware/check-ie.ts
+++ b/middleware/check-ie.ts
@@ -1,17 +1,17 @@
-import checkIE from 'check-ie'
-import { Context } from '@nuxt/types'
+import checkIE from "check-ie";
+import { Context } from "@nuxt/types";
 
 export default function (context: Context) {
-  const ua = process.server ? context.ssrContext?.req.headers['user-agent'] : window.navigator.userAgent
+  const ua = process.server ? context.ssrContext?.req.headers["user-agent"] : window.navigator.userAgent;
 
   if (ua) {
     const isIE = checkIE(ua, {
       ie10: true,
       ie11: true,
       edge: false, // Detect Internet Explorer, but not Edge
-    }).isIE
+    }).isIE;
     if (isIE) {
-      context.redirect('/unsupported.html')
+      context.redirect("/unsupported.html");
     }
   }
 }

--- a/middleware/okta-auth.ts
+++ b/middleware/okta-auth.ts
@@ -1,32 +1,32 @@
-import { Context } from '@nuxt/types'
-import Vue, { ComponentOptions } from 'vue'
+import { Context } from "@nuxt/types";
+import Vue, { ComponentOptions } from "vue";
 
 // Extended Vue component type providing access to all component options
 export interface VueComponent extends ComponentOptions<Vue> {
-  options: { [key: string]: any }
+  options: { [key: string]: any };
 }
 // Modified Route types using our extended VueComponent type
-type MatchedRoute = { components: VueComponent[] }
-type Route = { matched: MatchedRoute[] }
+type MatchedRoute = { components: VueComponent[] };
+type Route = { matched: MatchedRoute[] };
 
 function routeOption(route: Route, key: string, value: string | boolean): boolean {
   // A route can (technically) be associated with multiple Components,
   // so we pass a value we're looking for in each component's options
   // and return true if any of them have the value.
   return route.matched.some((m) => {
-    return Object.values(m.components).some((component) => component.options && component.options[key] === value)
-  })
+    return Object.values(m.components).some((component) => component.options && component.options[key] === value);
+  });
 }
 
 export default function ({ route, redirect, $okta }: Context) {
-  const skipAuth = routeOption(route as unknown as Route, 'auth', false)
+  const skipAuth = routeOption(route as unknown as Route, "auth", false);
   if (!skipAuth) {
-    const authState = $okta.authStateManager.getAuthState()
-    const signedIn = authState && authState.isAuthenticated
+    const authState = $okta.authStateManager.getAuthState();
+    const signedIn = authState && authState.isAuthenticated;
     if (!signedIn) {
-      $okta.setOriginalUri(route.fullPath)
-      redirect('/login')
+      $okta.setOriginalUri(route.fullPath);
+      redirect("/login");
     }
   }
-  return Promise.resolve()
+  return Promise.resolve();
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,49 +2,48 @@ export default {
   // Disable SSR, and build as an SPA
   ssr: false,
   // Use the Nuxt server to serve the SPA, allowing runtime config
-  target: 'server',
+  target: "server",
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    title: 'UKRDC Web Client',
+    title: "UKRDC Web Client",
     htmlAttrs: {
-      lang: 'en',
+      lang: "en",
     },
-    meta: [{
-        charset: 'utf-8',
+    meta: [
+      {
+        charset: "utf-8",
       },
       {
-        name: 'viewport',
-        content: 'width=device-width, initial-scale=1',
+        name: "viewport",
+        content: "width=device-width, initial-scale=1",
       },
       {
-        hid: 'description',
-        name: 'description',
-        content: '',
+        hid: "description",
+        name: "description",
+        content: "",
       },
     ],
   },
 
   server: {
-    host: process.env.HOST || 'localhost',
+    host: process.env.HOST || "localhost",
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css
-  css: [
-    '@/assets/css/main.css',
-  ],
+  css: ["@/assets/css/main.css"],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
-    '~/plugins/vuex-persistedstate.client.ts',
-    '~/plugins/v-calendar.client.ts',
-    '~/plugins/v-tooltip.client.ts',
-    '~/plugins/toast.client.ts',
-    '~/plugins/vue-clickaway.client.ts',
-    '~/plugins/okta-auth.client.ts',
-    '~/plugins/axios-ukrdc-api.client.ts',
-    '~/plugins/axios-error-handlers.ts',
-    '~/plugins/sentry-usercontext.client.ts',
+    "~/plugins/vuex-persistedstate.client.ts",
+    "~/plugins/v-calendar.client.ts",
+    "~/plugins/v-tooltip.client.ts",
+    "~/plugins/toast.client.ts",
+    "~/plugins/vue-clickaway.client.ts",
+    "~/plugins/okta-auth.client.ts",
+    "~/plugins/axios-ukrdc-api.client.ts",
+    "~/plugins/axios-error-handlers.ts",
+    "~/plugins/sentry-usercontext.client.ts",
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
@@ -52,13 +51,13 @@ export default {
 
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
   buildModules: [
-    '@nuxt/typescript-build',
-    '@nuxtjs/composition-api/module',
-    '@nuxt/postcss8' // Required for TailwindCSS
+    "@nuxt/typescript-build",
+    "@nuxtjs/composition-api/module",
+    "@nuxt/postcss8", // Required for TailwindCSS
   ],
 
   // Modules: https://go.nuxtjs.dev/config-modules
-  modules: ['@nuxtjs/axios', '@nuxtjs/sentry'],
+  modules: ["@nuxtjs/axios", "@nuxtjs/sentry"],
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
@@ -74,22 +73,24 @@ export default {
   sentry: {
     dsn: process.env.SENTRY_DSN,
     // Skip publish if no Sentry auth token is found at build-time
-    publishRelease: process.env.SENTRY_AUTH_TOKEN ? {
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
-      // Attach commits to the release (requires that the build triggered within a git repository).
-      setCommits: {
-        auto: true,
-      },
-    } : false,
-    sourceMapStyle: 'hidden-source-map',
+    publishRelease: process.env.SENTRY_AUTH_TOKEN
+      ? {
+          authToken: process.env.SENTRY_AUTH_TOKEN,
+          org: process.env.SENTRY_ORG,
+          project: process.env.SENTRY_PROJECT,
+          // Attach commits to the release (requires that the build triggered within a git repository).
+          setCommits: {
+            auto: true,
+          },
+        }
+      : false,
+    sourceMapStyle: "hidden-source-map",
     tracing: {
       tracesSampleRate: 1.0,
       vueOptions: {
         tracing: true,
         tracingOptions: {
-          hooks: ['mount', 'update'],
+          hooks: ["mount", "update"],
           timeout: 2000,
           trackComponents: true,
         },
@@ -100,15 +101,15 @@ export default {
 
   // Router and middleware configuration
   router: {
-    middleware: ['check-ie', 'okta-auth'],
-    base: process.env.APP_BASE_URL || '/new/app',
+    middleware: ["check-ie", "okta-auth"],
+    base: process.env.APP_BASE_URL || "/new/app",
   },
 
   // Build-time variables. These are resolved during the build process,
   // and can be accessed via `process.env.VAR_NAME` in the code.
   env: {
-    githubRef: process.env.GITHUB_REF || 'Not Available',
-    githubSha: process.env.GITHUB_SHA || 'Not Available',
+    githubRef: process.env.GITHUB_REF || "Not Available",
+    githubSha: process.env.GITHUB_SHA || "Not Available",
   },
 
   // Runtime configuration variables
@@ -116,29 +117,29 @@ export default {
     // Custom UKRDC API config
     api: {
       host: process.env.API_HOST,
-      base: process.env.API_BASE_URL || '/new/api',
+      base: process.env.API_BASE_URL || "/new/api",
     },
     // Okta domain
-    manageAccountUrl: process.env.MANAGE_ACCOUNT_URL || 'https://renalregistry.okta.com/app/UserHome',
+    manageAccountUrl: process.env.MANAGE_ACCOUNT_URL || "https://renalregistry.okta.com/app/UserHome",
     // Deployment environment
-    deploymentEnv: process.env.DEPLOYMENT_ENV || 'development',
+    deploymentEnv: process.env.DEPLOYMENT_ENV || "development",
     // Sentry public runtime config, see https://sentry.nuxtjs.org/sentry/runtime-config/
     sentry: {
       config: {
-        environment: process.env.DEPLOYMENT_ENV || 'development',
+        environment: process.env.DEPLOYMENT_ENV || "development",
       },
     },
     // Okta JS runtime config
     okta: {
       issuer: process.env.OAUTH_ISSUER,
       clientId: process.env.APP_CLIENT_ID,
-      redirectUri: '/login',
-      postLogoutRedirectUri: '/login',
+      redirectUri: "/login",
+      postLogoutRedirectUri: "/login",
       // Use authorization_code flow
-      responseType: 'code',
+      responseType: "code",
       pkce: true,
       // Extra options
-      scopes: ['openid', 'profile', 'email', 'offline_access'],
+      scopes: ["openid", "profile", "email", "offline_access"],
     },
   },
-}
+};

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -10,8 +10,7 @@ export default {
     htmlAttrs: {
       lang: 'en',
     },
-    meta: [
-      {
+    meta: [{
         charset: 'utf-8',
       },
       {
@@ -31,7 +30,9 @@ export default {
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css
-  css: [],
+  css: [
+    '@/assets/css/main.css',
+  ],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
@@ -50,31 +51,38 @@ export default {
   components: true,
 
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
-  buildModules: ['@nuxt/typescript-build', '@nuxtjs/composition-api/module', '@nuxtjs/tailwindcss'],
+  buildModules: [
+    '@nuxt/typescript-build',
+    '@nuxtjs/composition-api/module',
+    '@nuxt/postcss8' // Required for TailwindCSS
+  ],
 
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: ['@nuxtjs/axios', '@nuxtjs/sentry'],
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
-    transpile: [],
+    postcss: {
+      plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+      },
+    },
   },
 
   // Sentry Configuration: https://sentry.nuxtjs.org/guide/setup
   sentry: {
     dsn: process.env.SENTRY_DSN,
     // Skip publish if no Sentry auth token is found at build-time
-    publishRelease: process.env.SENTRY_AUTH_TOKEN
-      ? {
-          authToken: process.env.SENTRY_AUTH_TOKEN,
-          org: process.env.SENTRY_ORG,
-          project: process.env.SENTRY_PROJECT,
-          // Attach commits to the release (requires that the build triggered within a git repository).
-          setCommits: {
-            auto: true,
-          },
-        }
-      : false,
+    publishRelease: process.env.SENTRY_AUTH_TOKEN ? {
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      // Attach commits to the release (requires that the build triggered within a git repository).
+      setCommits: {
+        auto: true,
+      },
+    } : false,
     sourceMapStyle: 'hidden-source-map',
     tracing: {
       tracesSampleRate: 1.0,

--- a/package.json
+++ b/package.json
@@ -31,20 +31,22 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.15.7",
+    "@nuxt/postcss8": "^1.1.3",
     "@nuxt/types": "^2.15.3",
     "@nuxt/typescript-build": "^2.0.4",
     "@nuxtjs/eslint-config-typescript": "^8.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
-    "@nuxtjs/tailwindcss": "^4.2.0",
-    "@tailwindcss/forms": "^0.3.2",
-    "@tailwindcss/line-clamp": "^0.2.0",
+    "@tailwindcss/forms": "^0.4.0",
+    "@tailwindcss/line-clamp": "^0.3.1",
     "@types/chart.js": "^2.9.32",
     "@types/luxon": "^2.0.5",
+    "autoprefixer": "^10.4.2",
     "eslint": "^8.3.0",
     "eslint-config-prettier": "^8.2.0",
     "eslint-plugin-nuxt": "^3.1.0",
-    "postcss": "^8.3.7",
+    "postcss": "^8.4.5",
     "prettier": "^2.4.1",
-    "prettier-plugin-tailwindcss": "^0.1.3"
+    "prettier-plugin-tailwindcss": "^0.1.3",
+    "tailwindcss": "^3.0.17"
   }
 }

--- a/pages/codes.vue
+++ b/pages/codes.vue
@@ -64,52 +64,57 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { Code } from '@/interfaces/codes'
-import useQuery from '~/helpers/query/useQuery'
-import usePagination from '~/helpers/query/usePagination'
-import fetchCodes from '~/helpers/fetch/fetchCodes'
+import { Code } from "@/interfaces/codes";
+import useQuery from "~/helpers/query/useQuery";
+import usePagination from "~/helpers/query/usePagination";
+import fetchCodes from "~/helpers/fetch/fetchCodes";
 
 export default defineComponent({
   setup() {
-    const { page, total, size } = usePagination()
-    const { stringQuery } = useQuery()
-    const { fetchCodingStandards, fetchCodesPage } = fetchCodes()
+    const { page, total, size } = usePagination();
+    const { stringQuery } = useQuery();
+    const { fetchCodingStandards, fetchCodesPage } = fetchCodes();
 
     // Data refs
 
-    const standards = ref<string[]>()
-    const selectedStandard = stringQuery('standard', null, true, true)
+    const standards = ref<string[]>();
+    const selectedStandard = stringQuery("standard", null, true, true);
 
-    const codes = ref([] as Code[])
-    const selectedCode = ref<Code>()
+    const codes = ref([] as Code[]);
+    const selectedCode = ref<Code>();
 
-    const searchboxString = stringQuery('search', null, true, true)
+    const searchboxString = stringQuery("search", null, true, true);
 
-    const fetchInProgress = ref(false)
+    const fetchInProgress = ref(false);
 
     // Data fetching
     async function getCodes() {
-      fetchInProgress.value = true
+      fetchInProgress.value = true;
 
-      const codesPage = await fetchCodesPage(page.value || 1, size.value, selectedStandard.value, searchboxString.value)
-      codes.value = codesPage.items
-      total.value = codesPage.total
-      page.value = codesPage.page
-      size.value = codesPage.size
+      const codesPage = await fetchCodesPage(
+        page.value || 1,
+        size.value,
+        selectedStandard.value,
+        searchboxString.value
+      );
+      codes.value = codesPage.items;
+      total.value = codesPage.total;
+      page.value = codesPage.page;
+      size.value = codesPage.size;
 
-      fetchInProgress.value = false
+      fetchInProgress.value = false;
     }
 
     onMounted(async () => {
-      standards.value = await fetchCodingStandards()
-      getCodes()
-    })
+      standards.value = await fetchCodingStandards();
+      getCodes();
+    });
 
     watch([page, selectedStandard, searchboxString], () => {
-      getCodes()
-    })
+      getCodes();
+    });
 
     return {
       standards,
@@ -122,10 +127,10 @@ export default defineComponent({
       page,
       total,
       size,
-    }
+    };
   },
   head: {
-    title: 'Code List',
+    title: "Code List",
   },
-})
+});
 </script>

--- a/pages/codes/_id.vue
+++ b/pages/codes/_id.vue
@@ -6,16 +6,16 @@
       <div class="mb-4">
         <CodesTitle :code="code.code" :coding-standard="code.codingStandard" />
         <TextP class="mt-2">
-          {{ code.description || 'No description found' }}
+          {{ code.description || "No description found" }}
         </TextP>
       </div>
       <!-- Extra fields  -->
       <div class="mb-4">
         <div>
-          <TextL1 class="inline">Type: </TextL1><TextP class="inline">{{ code.objectType || 'None' }} </TextP>
+          <TextL1 class="inline">Type: </TextL1><TextP class="inline">{{ code.objectType || "None" }} </TextP>
         </div>
         <div class="mt-2">
-          <TextL1 class="inline">Units: </TextL1><TextP class="inline">{{ code.units || 'None' }} </TextP>
+          <TextL1 class="inline">Units: </TextL1><TextP class="inline">{{ code.units || "None" }} </TextP>
         </div>
       </div>
       <!-- Code lifecycle  -->
@@ -25,7 +25,7 @@
         </div>
         <div class="mt-2">
           <TextL1 class="inline">Updated: </TextL1
-          ><TextP class="inline">{{ code.updateDate ? formatDate(code.updateDate) : 'Never updated' }} </TextP>
+          ><TextP class="inline">{{ code.updateDate ? formatDate(code.updateDate) : "Never updated" }} </TextP>
         </div>
       </div>
       <!-- Links -->
@@ -69,63 +69,63 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useMeta, useRoute, watch } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { ExtendedCode } from '@/interfaces/codes'
-import fetchCodes from '~/helpers/fetch/fetchCodes'
+import { computed, defineComponent, onMounted, ref, useMeta, useRoute, watch } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { ExtendedCode } from "@/interfaces/codes";
+import fetchCodes from "~/helpers/fetch/fetchCodes";
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-    const { fetchCode } = fetchCodes()
+    const route = useRoute();
+    const { fetchCode } = fetchCodes();
 
     // Head
-    const { title } = useMeta()
-    title.value = `Code ${route.value.params.id}`
+    const { title } = useMeta();
+    title.value = `Code ${route.value.params.id}`;
 
     // Data refs
 
-    const code = ref<ExtendedCode>()
+    const code = ref<ExtendedCode>();
 
     // Data fetching
 
     async function getCode() {
       // Scroll to top every time we fetch a new code
       if (process.client) {
-        document.getElementsByTagName('main')[0].scrollTop = 0
+        document.getElementsByTagName("main")[0].scrollTop = 0;
       }
       // Fetch code details
-      code.value = await fetchCode(route.value.params.id)
+      code.value = await fetchCode(route.value.params.id);
     }
 
     onMounted(() => {
-      getCode()
-    })
+      getCode();
+    });
 
     watch(
       () => route.value.params.id, // Watch the computed (reactive) value of params.id
       () => {
-        getCode()
+        getCode();
       }
-    )
+    );
 
     // External code links
 
     const externalLink = computed(() => {
       if (!code.value) {
-        return null
+        return null;
       }
-      if (code.value.codingStandard === 'LOINC') {
-        return `https://loinc.org/${code.value.code}/`
+      if (code.value.codingStandard === "LOINC") {
+        return `https://loinc.org/${code.value.code}/`;
       }
-      if (code.value.codingStandard === 'SNOMED') {
-        return `https://termbrowser.nhs.uk/?perspective=full&conceptId1=${code.value.code}`
+      if (code.value.codingStandard === "SNOMED") {
+        return `https://termbrowser.nhs.uk/?perspective=full&conceptId1=${code.value.code}`;
       }
-      return null
-    })
+      return null;
+    });
 
-    return { formatDate, externalLink, code }
+    return { formatDate, externalLink, code };
   },
   head: {},
-})
+});
 </script>

--- a/pages/empi/index.vue
+++ b/pages/empi/index.vue
@@ -22,9 +22,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   setup() {},
-})
+});
 </script>

--- a/pages/empi/merge.vue
+++ b/pages/empi/merge.vue
@@ -38,7 +38,7 @@
         <div class="flex-shrink">
           <button
             v-tooltip="'Switch Records'"
-            class="focus:outline-none mx-auto block w-8 rounded-md border border-gray-300 bg-white font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            class="mx-auto block w-8 rounded-md border border-gray-300 bg-white font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             @click="switchRecords"
           >
             <IconSwitchH class="my-2 hidden lg:block" /><IconSwitchV class="my-2 block lg:hidden" />
@@ -107,144 +107,144 @@
 </template>
 
 <script lang="ts">
-import { computed, ref, useContext, useRoute, useRouter, watch } from '@nuxtjs/composition-api'
-import { defineComponent, onMounted } from '@vue/composition-api'
+import { computed, ref, useContext, useRoute, useRouter, watch } from "@nuxtjs/composition-api";
+import { defineComponent, onMounted } from "@vue/composition-api";
 
-import useQuery from '~/helpers/query/useQuery'
-import fetchEMPI from '~/helpers/fetch/fetchEMPI'
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import useQuery from "~/helpers/query/useQuery";
+import fetchEMPI from "~/helpers/fetch/fetchEMPI";
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
-import { modalInterface } from '~/interfaces/modal'
-import { MasterRecord } from '~/interfaces/masterrecord'
+import { modalInterface } from "~/interfaces/modal";
+import { MasterRecord } from "~/interfaces/masterrecord";
 
 enum Direction {
-  superseding = 'superseding',
-  Superceeded = 'superseded',
+  superseding = "superseding",
+  Superceeded = "superseded",
 }
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-    const router = useRouter()
-    const { $toast } = useContext()
-    const { stringQuery } = useQuery()
-    const { PostEMPIMerge } = fetchEMPI()
-    const { fetchMasterRecord } = fetchMasterRecords()
+    const route = useRoute();
+    const router = useRouter();
+    const { $toast } = useContext();
+    const { stringQuery } = useQuery();
+    const { PostEMPIMerge } = fetchEMPI();
+    const { fetchMasterRecord } = fetchMasterRecords();
 
     // Modals
 
-    const beginMergeAlert = ref<modalInterface>()
+    const beginMergeAlert = ref<modalInterface>();
 
     // Data refs
 
-    const supersededId = stringQuery('superseded', null, true, false)
-    const supersedingId = stringQuery('superseding', null, true, false)
-    const callbackPath = stringQuery('callback', null)
+    const supersededId = stringQuery("superseded", null, true, false);
+    const supersedingId = stringQuery("superseding", null, true, false);
+    const callbackPath = stringQuery("callback", null);
 
-    const superseded = ref<MasterRecord>()
-    const superseding = ref<MasterRecord>()
+    const superseded = ref<MasterRecord>();
+    const superseding = ref<MasterRecord>();
 
-    const searchingFor = ref<Direction>()
+    const searchingFor = ref<Direction>();
 
     const readyToMerge = computed(() => {
-      return superseded.value?.id && superseding.value?.id && superseded.value?.id !== superseding.value?.id
-    })
+      return superseded.value?.id && superseding.value?.id && superseded.value?.id !== superseding.value?.id;
+    });
 
     const mergeBlockDescription = computed(() => {
       if (superseded.value?.id && superseding.value?.id) {
         if (superseded.value?.id === superseding.value?.id) {
-          return 'A record cannot be merged into itself. Please select a different record on one side.'
+          return "A record cannot be merged into itself. Please select a different record on one side.";
         }
         if (superseded.value?.nationalidType !== superseding.value?.nationalidType) {
-          return `You are about to merge a ${superseded.value?.nationalidType} record into a ${superseding.value?.nationalidType} record.`
+          return `You are about to merge a ${superseded.value?.nationalidType} record into a ${superseding.value?.nationalidType} record.`;
         }
       }
-      return ''
-    })
+      return "";
+    });
 
     // Data fetching
     async function fetchRecords() {
       if (supersededId.value) {
-        superseded.value = await fetchMasterRecord(supersededId.value)
+        superseded.value = await fetchMasterRecord(supersededId.value);
       }
       if (supersedingId.value) {
-        superseding.value = await fetchMasterRecord(supersedingId.value)
+        superseding.value = await fetchMasterRecord(supersedingId.value);
       }
     }
 
     onMounted(() => {
-      fetchRecords()
-    })
+      fetchRecords();
+    });
 
     watch([supersededId, supersedingId], () => {
-      fetchRecords()
-    })
+      fetchRecords();
+    });
 
     // Record card style
 
     const highlightSections = computed<string[]>(() => {
       if (!(superseding.value && superseded.value)) {
-        return []
+        return [];
       }
-      const highlight = []
+      const highlight = [];
       if (
         superseding.value.givenname !== superseded.value.givenname ||
         superseding.value.surname !== superseded.value.surname
       ) {
-        highlight.push('name')
+        highlight.push("name");
       }
       if (superseding.value.dateOfBirth !== superseded.value.dateOfBirth) {
-        highlight.push('dateOfBirth')
+        highlight.push("dateOfBirth");
       }
       if (superseding.value.gender !== superseded.value.gender) {
-        highlight.push('gender')
+        highlight.push("gender");
       }
-      return highlight
-    })
+      return highlight;
+    });
 
     // Edit merge functions
 
     function switchRecords() {
-      const newQuery = Object.assign({}, route.value.query)
-      newQuery.superseded = [supersedingId.value]
-      newQuery.superseding = [supersededId.value]
+      const newQuery = Object.assign({}, route.value.query);
+      newQuery.superseded = [supersedingId.value];
+      newQuery.superseding = [supersededId.value];
       router.push({
         path: route.value.path,
         query: newQuery,
-      })
+      });
     }
 
     function clearMerge() {
-      superseding.value = undefined
-      superseded.value = undefined
-      searchingFor.value = undefined
-      const newQuery = Object.assign({}, route.value.query)
-      newQuery.superseded = [null]
-      newQuery.superseding = [null]
+      superseding.value = undefined;
+      superseded.value = undefined;
+      searchingFor.value = undefined;
+      const newQuery = Object.assign({}, route.value.query);
+      newQuery.superseded = [null];
+      newQuery.superseding = [null];
       router.push({
         path: route.value.path,
         query: newQuery,
-      })
+      });
     }
 
     function clearsuperseding() {
-      superseding.value = undefined
-      supersedingId.value = null
-      searchingFor.value = Direction.superseding
+      superseding.value = undefined;
+      supersedingId.value = null;
+      searchingFor.value = Direction.superseding;
     }
 
     function clearSuperceeded() {
-      superseded.value = undefined
-      supersededId.value = null
-      searchingFor.value = Direction.Superceeded
+      superseded.value = undefined;
+      supersededId.value = null;
+      searchingFor.value = Direction.Superceeded;
     }
 
     function selectsuperseding(id: string) {
-      supersedingId.value = id
+      supersedingId.value = id;
     }
 
     function selectSuperceeded(id: string) {
-      supersededId.value = id
+      supersededId.value = id;
     }
 
     // Do merge
@@ -254,21 +254,21 @@ export default defineComponent({
         PostEMPIMerge(superseding.value.id, superseded.value.id)
           .then(() => {
             $toast.show({
-              type: 'success',
-              title: 'Success',
-              message: 'Record merge request sent successfully',
+              type: "success",
+              title: "Success",
+              message: "Record merge request sent successfully",
               timeout: 10,
-              classTimeout: 'bg-green-600',
-            })
-            clearMerge()
+              classTimeout: "bg-green-600",
+            });
+            clearMerge();
             if (callbackPath.value) {
-              router.push(callbackPath.value)
+              router.push(callbackPath.value);
             }
           })
           .finally(() => {
-            const el = beginMergeAlert.value as modalInterface
-            el.hide()
-          })
+            const el = beginMergeAlert.value as modalInterface;
+            el.hide();
+          });
       }
     }
 
@@ -289,7 +289,7 @@ export default defineComponent({
       readyToMerge,
       mergeBlockDescription,
       requestMerge,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/empi/multipleids.vue
+++ b/pages/empi/multipleids.vue
@@ -61,52 +61,52 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { MultipleUKRDCIDsGroup } from '@/interfaces/datahealth'
-import usePagination from '~/helpers/query/usePagination'
+import { MultipleUKRDCIDsGroup } from "@/interfaces/datahealth";
+import usePagination from "~/helpers/query/usePagination";
 
-import fetchDataHealth from '~/helpers/fetch/fetchDataHealth'
-import { LastRunTime } from '~/interfaces/admin'
+import fetchDataHealth from "~/helpers/fetch/fetchDataHealth";
+import { LastRunTime } from "~/interfaces/admin";
 
 export default defineComponent({
   setup() {
-    const { page, total, size } = usePagination()
-    const { fetchMultipleUKRDCIDsPage, fetchMultipleUKRDCIDsLastRun } = fetchDataHealth()
+    const { page, total, size } = usePagination();
+    const { fetchMultipleUKRDCIDsPage, fetchMultipleUKRDCIDsLastRun } = fetchDataHealth();
 
     // Data refs
-    size.value = 10 // Get 10 groups as we expect a couple of records per group
+    size.value = 10; // Get 10 groups as we expect a couple of records per group
 
-    const groups = ref<MultipleUKRDCIDsGroup[]>()
-    const fetchInProgress = ref(false)
+    const groups = ref<MultipleUKRDCIDsGroup[]>();
+    const fetchInProgress = ref(false);
 
-    const lastRunTime = ref<string>()
+    const lastRunTime = ref<string>();
 
     // Data fetching
     async function getGroups() {
-      fetchInProgress.value = true
+      fetchInProgress.value = true;
 
-      const groupsPage = await fetchMultipleUKRDCIDsPage(page.value || 1, size.value)
-      groups.value = groupsPage.items
-      total.value = groupsPage.total
-      page.value = groupsPage.page
-      size.value = groupsPage.size
+      const groupsPage = await fetchMultipleUKRDCIDsPage(page.value || 1, size.value);
+      groups.value = groupsPage.items;
+      total.value = groupsPage.total;
+      page.value = groupsPage.page;
+      size.value = groupsPage.size;
 
-      fetchInProgress.value = false
+      fetchInProgress.value = false;
     }
 
     onMounted(() => {
-      getGroups()
+      getGroups();
       fetchMultipleUKRDCIDsLastRun().then((response: LastRunTime) => {
-        console.log(response)
-        lastRunTime.value = response.lastRunTime
-      })
-    })
+        console.log(response);
+        lastRunTime.value = response.lastRunTime;
+      });
+    });
 
     watch(page, () => {
-      getGroups()
-    })
+      getGroups();
+    });
 
     return {
       groups,
@@ -116,7 +116,7 @@ export default defineComponent({
       total,
       size,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/facilities/_code.vue
+++ b/pages/facilities/_code.vue
@@ -5,24 +5,24 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, useMeta, useRoute } from '@nuxtjs/composition-api'
+import { computed, defineComponent, useMeta, useRoute } from "@nuxtjs/composition-api";
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
+    const route = useRoute();
 
     // Head
-    const { title } = useMeta()
-    title.value = `${route.value.params.code}`
+    const { title } = useMeta();
+    title.value = `${route.value.params.code}`;
 
-    const facilityCode = computed(() => route.value.params.code)
+    const facilityCode = computed(() => route.value.params.code);
     return {
       facilityCode,
-    }
+    };
   },
 
   head: {
-    title: 'Facility',
+    title: "Facility",
   },
-})
+});
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,44 +16,44 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
-import { DashResponse } from '@/interfaces/dash'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
+import { DashResponse } from "@/interfaces/dash";
 
-import fetchDash from '~/helpers/fetch/fetchDash'
+import fetchDash from "~/helpers/fetch/fetchDash";
 
-import usePermissions from '~/helpers/usePermissions'
-import useAuth from '~/helpers/useAuth'
+import usePermissions from "~/helpers/usePermissions";
+import useAuth from "~/helpers/useAuth";
 
 export default defineComponent({
   setup() {
-    const { signedIn } = useAuth()
-    const { isAdmin, getFacilities, hasMultipleFacilities } = usePermissions()
-    const { fetchDashboard } = fetchDash()
+    const { signedIn } = useAuth();
+    const { isAdmin, getFacilities, hasMultipleFacilities } = usePermissions();
+    const { fetchDashboard } = fetchDash();
 
     // Data refs
 
-    const dash = ref<DashResponse>()
+    const dash = ref<DashResponse>();
 
     const availableFacilities = computed(() => {
-      return getFacilities()
-    })
+      return getFacilities();
+    });
 
     onMounted(async () => {
       if (signedIn()) {
-        dash.value = await fetchDashboard()
+        dash.value = await fetchDashboard();
       }
-    })
+    });
 
     return {
       dash,
       hasMultipleFacilities,
       availableFacilities,
       isAdmin,
-    }
+    };
   },
 
   head: {
-    title: 'Dashboard',
+    title: "Dashboard",
   },
-})
+});
 </script>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -5,50 +5,50 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeMount, useRouter } from '@nuxtjs/composition-api'
+import { defineComponent, onBeforeMount, useRouter } from "@nuxtjs/composition-api";
 
-import useAuth from '~/helpers/useAuth'
+import useAuth from "~/helpers/useAuth";
 
 export default defineComponent({
   // Override auth middleware. We handle redirects here ourselves in mounted()
   auth: false,
 
   setup() {
-    const { oktaAuth, signedIn } = useAuth()
-    const router = useRouter()
+    const { oktaAuth, signedIn } = useAuth();
+    const router = useRouter();
 
     onBeforeMount(() => {
-      const originalUri = oktaAuth.getOriginalUri()
+      const originalUri = oktaAuth.getOriginalUri();
       if (oktaAuth.isLoginRedirect()) {
         // If we're in the middle of a sign-in flow
         // Fetch tokens and redirect back to originalUri
-        oktaAuth.handleLoginRedirect()
+        oktaAuth.handleLoginRedirect();
       } else if (!signedIn()) {
         // If we're not currently signed in
         // Check if we were redirected here from another page
         if (!originalUri) {
           // If we weren't redirected here from another page,
           // redirect back to the home page after login
-          oktaAuth.setOriginalUri('/')
+          oktaAuth.setOriginalUri("/");
         }
         // Start sign-in flow
-        oktaAuth.signInWithRedirect()
+        oktaAuth.signInWithRedirect();
       } else if (originalUri) {
         // If we're signed in and an originalUri somehow exists
-        router.replace({ path: originalUri })
+        router.replace({ path: originalUri });
       } else {
         // If we're signed in and no originalUri exists
         // Redirect to home
-        router.replace({ path: '/' })
+        router.replace({ path: "/" });
       }
-    })
+    });
 
     return {
       oktaAuth,
-    }
+    };
   },
   head: {
-    title: 'Login',
+    title: "Login",
   },
-})
+});
 </script>

--- a/pages/masterrecords/_id.vue
+++ b/pages/masterrecords/_id.vue
@@ -28,106 +28,106 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useMeta, useRoute } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, useMeta, useRoute } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
-import { insertIf } from '@/helpers/utils/arrayUtils'
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
+import { insertIf } from "@/helpers/utils/arrayUtils";
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
-import { MasterRecord, MasterRecordStatistics } from '@/interfaces/masterrecord'
-import { TabItem } from '@/interfaces/tabs'
-import usePermissions from '~/helpers/usePermissions'
+import { MasterRecord, MasterRecordStatistics } from "@/interfaces/masterrecord";
+import { TabItem } from "@/interfaces/tabs";
+import usePermissions from "~/helpers/usePermissions";
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-    const { fetchMasterRecord, fetchMasterRecordStatistics } = fetchMasterRecords()
-    const { hasPermission } = usePermissions()
+    const route = useRoute();
+    const { fetchMasterRecord, fetchMasterRecordStatistics } = fetchMasterRecords();
+    const { hasPermission } = usePermissions();
 
     // Head
-    const { title } = useMeta()
-    title.value = `Record ${route.value.params.id}`
+    const { title } = useMeta();
+    title.value = `Record ${route.value.params.id}`;
 
     // Navigation
 
     const tabs = [
       {
-        name: 'Overview',
+        name: "Overview",
         href: `/masterrecords/${route.value.params.id}`,
       },
-      ...insertIf(hasPermission('ukrdc:messages:read'), {
-        name: 'Messages',
+      ...insertIf(hasPermission("ukrdc:messages:read"), {
+        name: "Messages",
         href: `/masterrecords/${route.value.params.id}/messages`,
       }),
       {
-        name: 'Link Records',
+        name: "Link Records",
         href: `/masterrecords/${route.value.params.id}/linkrecords`,
       },
       {
-        name: 'Issues',
+        name: "Issues",
         href: `/masterrecords/${route.value.params.id}/issues`,
       },
-      ...insertIf(hasPermission('ukrdc:audit:records:read'), {
-        name: 'Audit',
+      ...insertIf(hasPermission("ukrdc:audit:records:read"), {
+        name: "Audit",
         href: `/masterrecords/${route.value.params.id}/audit`,
       }),
-    ] as TabItem[]
+    ] as TabItem[];
 
     // Data refs
 
-    const record = ref<MasterRecord>()
-    const stats = ref<MasterRecordStatistics>()
+    const record = ref<MasterRecord>();
+    const stats = ref<MasterRecordStatistics>();
 
     // Data fetching
 
     async function fetchRecord() {
-      record.value = await fetchMasterRecord(route.value.params.id)
+      record.value = await fetchMasterRecord(route.value.params.id);
 
       // Get basic record statistics
-      stats.value = await fetchMasterRecordStatistics(record.value)
-      issueMessage.value = buildErrorMessage(stats.value)
+      stats.value = await fetchMasterRecordStatistics(record.value);
+      issueMessage.value = buildErrorMessage(stats.value);
     }
 
     onMounted(() => {
-      fetchRecord()
-    })
+      fetchRecord();
+    });
 
     // Dynamic UI elements
 
-    const issueMessage = ref<string>()
+    const issueMessage = ref<string>();
 
     function buildErrorMessage(stats?: MasterRecordStatistics): string {
-      let msg = ''
-      let workItemsMsg = ''
-      let errorMsg = ''
+      let msg = "";
+      let workItemsMsg = "";
+      let errorMsg = "";
       if (stats) {
         if (stats?.workitems > 0) {
-          workItemsMsg += `${stats?.workitems} workitem`
+          workItemsMsg += `${stats?.workitems} workitem`;
         }
         if (stats?.workitems > 1) {
-          workItemsMsg += 's'
+          workItemsMsg += "s";
         }
         if (stats?.errors > 0) {
-          errorMsg += `${stats?.errors} error`
+          errorMsg += `${stats?.errors} error`;
         }
         if (stats?.errors > 1) {
-          errorMsg += 's'
+          errorMsg += "s";
         }
       }
       if (workItemsMsg) {
-        msg += workItemsMsg
+        msg += workItemsMsg;
       }
       if (workItemsMsg && errorMsg) {
-        msg += ' and '
+        msg += " and ";
       }
       if (errorMsg) {
-        msg += errorMsg
+        msg += errorMsg;
       }
       if (workItemsMsg || errorMsg) {
-        msg += ' found on record. Click for details.'
+        msg += " found on record. Click for details.";
       }
-      return msg
+      return msg;
     }
 
     return {
@@ -137,12 +137,12 @@ export default defineComponent({
       issueMessage,
       formatGender,
       formatDate,
-    }
+    };
   },
   head: {
-    title: 'Master Record',
+    title: "Master Record",
   },
-})
+});
 </script>
 
 <style></style>

--- a/pages/masterrecords/_id/audit.vue
+++ b/pages/masterrecords/_id/audit.vue
@@ -39,17 +39,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { nowString } from '@/helpers/utils/dateUtils'
-import usePagination from '~/helpers/query/usePagination'
-import useSortBy from '~/helpers/query/useSortBy'
-import useDateRange from '~/helpers/query/useDateRange'
+import { nowString } from "@/helpers/utils/dateUtils";
+import usePagination from "~/helpers/query/usePagination";
+import useSortBy from "~/helpers/query/useSortBy";
+import useDateRange from "~/helpers/query/useDateRange";
 
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
-import { AuditEvent } from '~/interfaces/audit'
-import { MasterRecord } from '~/interfaces/masterrecord'
+import { AuditEvent } from "~/interfaces/audit";
+import { MasterRecord } from "~/interfaces/masterrecord";
 
 export default defineComponent({
   props: {
@@ -59,16 +59,16 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { page, total, size } = usePagination()
-    const { makeDateRange } = useDateRange()
-    const { orderAscending, orderBy, toggleOrder } = useSortBy()
-    const { fetchMasterRecordAuditPage } = fetchMasterRecords()
+    const { page, total, size } = usePagination();
+    const { makeDateRange } = useDateRange();
+    const { orderAscending, orderBy, toggleOrder } = useSortBy();
+    const { fetchMasterRecordAuditPage } = fetchMasterRecords();
 
     // Set initial date dateRange
-    const dateRange = makeDateRange(nowString(-30), nowString(0), true)
+    const dateRange = makeDateRange(nowString(-30), nowString(0), true);
 
     // Data refs
-    const events = ref<AuditEvent[]>()
+    const events = ref<AuditEvent[]>();
 
     // Data fetching
 
@@ -80,17 +80,17 @@ export default defineComponent({
         orderBy.value,
         dateRange.value.start,
         dateRange.value.end
-      )
+      );
 
-      events.value = eventsPage.items
-      total.value = eventsPage.total
-      page.value = eventsPage.page
-      size.value = eventsPage.size
+      events.value = eventsPage.items;
+      total.value = eventsPage.total;
+      page.value = eventsPage.page;
+      size.value = eventsPage.size;
     }
 
     onMounted(() => {
-      fetchEvents()
-    })
+      fetchEvents();
+    });
 
     watch(
       [
@@ -99,9 +99,9 @@ export default defineComponent({
         () => JSON.stringify(dateRange), // Stringify to watch for actual value changes
       ],
       () => {
-        fetchEvents()
+        fetchEvents();
       }
-    )
+    );
 
     return {
       page,
@@ -112,7 +112,7 @@ export default defineComponent({
       orderAscending,
       orderBy,
       toggleOrder,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/masterrecords/_id/index.vue
+++ b/pages/masterrecords/_id/index.vue
@@ -105,17 +105,17 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
-import { isTracing } from '@/helpers/utils/recordUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
+import { isTracing } from "@/helpers/utils/recordUtils";
 
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
-import { MasterRecord, MasterRecordStatistics } from '@/interfaces/masterrecord'
-import { PatientRecordSummary } from '@/interfaces/patientrecord'
-import { MinimalMessage } from '~/interfaces/messages'
+import { MasterRecord, MasterRecordStatistics } from "@/interfaces/masterrecord";
+import { PatientRecordSummary } from "@/interfaces/patientrecord";
+import { MinimalMessage } from "~/interfaces/messages";
 
 export default defineComponent({
   props: {
@@ -132,92 +132,92 @@ export default defineComponent({
 
   setup(props) {
     const { fetchMasterRecordRelated, fetchMasterRecordLatestMessage, fetchMasterRecordPatientRecords } =
-      fetchMasterRecords()
+      fetchMasterRecords();
 
     // Data refs
 
-    const relatedRecords = ref<MasterRecord[]>()
-    const patientRecords = ref<PatientRecordSummary[]>()
-    const latestMessage = ref<MinimalMessage | null | undefined>(undefined)
+    const relatedRecords = ref<MasterRecord[]>();
+    const patientRecords = ref<PatientRecordSummary[]>();
+    const latestMessage = ref<MinimalMessage | null | undefined>(undefined);
 
     // Data fetching
     function fetchRelatedRecordData() {
       fetchMasterRecordPatientRecords(props.record).then((records) => {
-        patientRecords.value = records
-      })
+        patientRecords.value = records;
+      });
 
       fetchMasterRecordRelated(props.record).then((records) => {
-        relatedRecords.value = records
-      })
+        relatedRecords.value = records;
+      });
 
       fetchMasterRecordLatestMessage(props.record).then((message) => {
-        latestMessage.value = message
-      })
+        latestMessage.value = message;
+      });
     }
 
     onMounted(() => {
-      fetchRelatedRecordData()
-    })
+      fetchRelatedRecordData();
+    });
 
     function refreshRecords() {
-      fetchRelatedRecordData()
+      fetchRelatedRecordData();
     }
 
     // Tracing record matching
 
     const tracingRecord = computed<PatientRecordSummary | null>(() => {
-      const tracings = patientRecords.value?.filter(isTracing)
+      const tracings = patientRecords.value?.filter(isTracing);
       if (!tracings || (tracings && tracings.length < 1)) {
-        return null
+        return null;
       }
-      return tracings[0]
-    })
+      return tracings[0];
+    });
 
     function givenNameMatchesTracing() {
       if (!tracingRecord.value) {
-        return false
+        return false;
       }
       for (const name of tracingRecord.value.patient.names) {
         if (props.record.givenname.toLowerCase() === name.given.toLowerCase()) {
-          return true
+          return true;
         }
       }
-      return false
+      return false;
     }
 
     function surnameMatchesTracing() {
       if (!tracingRecord.value) {
-        return false
+        return false;
       }
       for (const name of tracingRecord.value.patient.names) {
         if (props.record.surname.toLowerCase() === name.family.toLowerCase()) {
-          return true
+          return true;
         }
       }
-      return false
+      return false;
     }
 
     const nameMatchesTracing = computed(() => {
-      return givenNameMatchesTracing() && surnameMatchesTracing()
-    })
+      return givenNameMatchesTracing() && surnameMatchesTracing();
+    });
 
     // Dynamic UI elements
 
     const latestMessageInfo = computed(() => {
       if (!latestMessage.value) {
-        return null
+        return null;
       }
-      if (latestMessage.value.msgStatus === 'ERROR') {
+      if (latestMessage.value.msgStatus === "ERROR") {
         return `Latest file ${latestMessage.value.filename} failed from ${latestMessage.value.facility} on ${formatDate(
           latestMessage.value.received,
           false
-        )}`
+        )}`;
       }
       return `Latest file ${latestMessage.value.filename} recieved from ${latestMessage.value.facility} on ${formatDate(
         latestMessage.value.received,
         false
-      )}`
-    })
+      )}`;
+    });
 
     return {
       patientRecords,
@@ -229,9 +229,9 @@ export default defineComponent({
       formatGender,
       formatDate,
       nameMatchesTracing,
-    }
+    };
   },
-})
+});
 </script>
 
 <style></style>

--- a/pages/masterrecords/_id/issues.vue
+++ b/pages/masterrecords/_id/issues.vue
@@ -50,18 +50,18 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
 
-import { MasterRecord, MasterRecordStatistics } from '@/interfaces/masterrecord'
-import { WorkItem } from '@/interfaces/workitem'
-import { MultipleUKRDCIDsGroup } from '@/interfaces/datahealth'
+import { MasterRecord, MasterRecordStatistics } from "@/interfaces/masterrecord";
+import { WorkItem } from "@/interfaces/workitem";
+import { MultipleUKRDCIDsGroup } from "@/interfaces/datahealth";
 
-import usePermissions from '~/helpers/usePermissions'
-import { Message } from '~/interfaces/messages'
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import usePermissions from "~/helpers/usePermissions";
+import { Message } from "~/interfaces/messages";
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
 export default defineComponent({
   props: {
@@ -76,26 +76,27 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { fetchMasterRecordRelated, fetchMasterRecordMessagesPage, fetchMasterRecordWorkItems } = fetchMasterRecords()
-    const { hasPermission } = usePermissions()
+    const { fetchMasterRecordRelated, fetchMasterRecordMessagesPage, fetchMasterRecordWorkItems } =
+      fetchMasterRecords();
+    const { hasPermission } = usePermissions();
 
     // Data refs
-    const workItems = ref([] as WorkItem[])
+    const workItems = ref([] as WorkItem[]);
 
-    const relatedErrors = ref([] as Message[])
-    const relatedErrorsPage = ref(1)
-    const relatedErrorsSize = ref(5)
-    const relatedErrorsTotal = ref(0)
+    const relatedErrors = ref([] as Message[]);
+    const relatedErrorsPage = ref(1);
+    const relatedErrorsSize = ref(5);
+    const relatedErrorsTotal = ref(0);
 
-    const ukrdcIdGroup = ref<MultipleUKRDCIDsGroup>()
-    const hasMultipleUKRDCIDs = ref(false)
+    const ukrdcIdGroup = ref<MultipleUKRDCIDsGroup>();
+    const hasMultipleUKRDCIDs = ref(false);
 
     // Data fetching
 
     async function fetchWorkItems() {
       // Use the record links to load related data concurrently
-      if (hasPermission('ukrdc:workitems:read')) {
-        workItems.value = await fetchMasterRecordWorkItems(props.record)
+      if (hasPermission("ukrdc:workitems:read")) {
+        workItems.value = await fetchMasterRecordWorkItems(props.record);
       }
     }
 
@@ -104,59 +105,59 @@ export default defineComponent({
         props.record,
         relatedErrorsPage.value || 1,
         relatedErrorsSize.value,
-        'desc',
-        ['ERROR'], // Status filter
+        "desc",
+        ["ERROR"], // Status filter
         null, // Since filter
         null // Until filter
-      )
+      );
       // Set related errors
-      relatedErrors.value = res.items
-      relatedErrorsPage.value = res.page
-      relatedErrorsSize.value = res.size
-      relatedErrorsTotal.value = res.total
+      relatedErrors.value = res.items;
+      relatedErrorsPage.value = res.page;
+      relatedErrorsSize.value = res.size;
+      relatedErrorsTotal.value = res.total;
     }
 
     function fetchMultipleUKRDCIds() {
       // If we haven't already fetched the multiple records, and multiple records exist
       if (!hasMultipleUKRDCIDs.value && props.stats?.ukrdcids > 1) {
         // Stop the request from triggering again
-        hasMultipleUKRDCIDs.value = true
+        hasMultipleUKRDCIDs.value = true;
 
-        fetchMasterRecordRelated(props.record, false, 'UKRDC').then((records) => {
+        fetchMasterRecordRelated(props.record, false, "UKRDC").then((records) => {
           // Create a "synthetic" MultipleUKRDCIDsGroup
           // We do this so that we can re-use the component used in the EMPI Data Health page
           const multipleIdsGroup = {
             groupId: null,
             records: [],
-          } as MultipleUKRDCIDsGroup
+          } as MultipleUKRDCIDsGroup;
 
           for (const record of records) {
             multipleIdsGroup.records.push({
               lastUpdated: null,
               masterRecord: record,
-            })
+            });
           }
-          ukrdcIdGroup.value = multipleIdsGroup
-        })
+          ukrdcIdGroup.value = multipleIdsGroup;
+        });
       }
     }
 
     onMounted(async () => {
-      fetchMultipleUKRDCIds()
-      fetchWorkItems()
-      await updateRelatedErrors()
-    })
+      fetchMultipleUKRDCIds();
+      fetchWorkItems();
+      await updateRelatedErrors();
+    });
 
     watch(relatedErrorsPage, () => {
-      updateRelatedErrors()
-    })
+      updateRelatedErrors();
+    });
 
     watch(
       () => props.stats,
       () => {
-        fetchMultipleUKRDCIds()
+        fetchMultipleUKRDCIds();
       }
-    )
+    );
 
     return {
       workItems,
@@ -167,9 +168,9 @@ export default defineComponent({
       ukrdcIdGroup,
       formatGender,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>
 
 <style></style>

--- a/pages/masterrecords/_id/linkrecords.vue
+++ b/pages/masterrecords/_id/linkrecords.vue
@@ -8,15 +8,15 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
 
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
-import { MasterRecord, MasterRecordStatistics } from '@/interfaces/masterrecord'
-import { LinkRecord } from '@/interfaces/linkrecords'
+import { MasterRecord, MasterRecordStatistics } from "@/interfaces/masterrecord";
+import { LinkRecord } from "@/interfaces/linkrecords";
 
 export default defineComponent({
   props: {
@@ -31,24 +31,24 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { fetchMasterRecordLinkRecords } = fetchMasterRecords()
+    const { fetchMasterRecordLinkRecords } = fetchMasterRecords();
 
     // Data refs
 
-    const linkRecords = ref<LinkRecord[]>()
+    const linkRecords = ref<LinkRecord[]>();
 
     // Data fetching
     onMounted(async () => {
-      linkRecords.value = await fetchMasterRecordLinkRecords(props.record)
-    })
+      linkRecords.value = await fetchMasterRecordLinkRecords(props.record);
+    });
 
     return {
       linkRecords,
       formatGender,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>
 
 <style></style>

--- a/pages/masterrecords/_id/messages.vue
+++ b/pages/masterrecords/_id/messages.vue
@@ -41,17 +41,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { nowString } from '@/helpers/utils/dateUtils'
-import usePagination from '~/helpers/query/usePagination'
-import useSortBy from '~/helpers/query/useSortBy'
-import useDateRange from '~/helpers/query/useDateRange'
+import { nowString } from "@/helpers/utils/dateUtils";
+import usePagination from "~/helpers/query/usePagination";
+import useSortBy from "~/helpers/query/useSortBy";
+import useDateRange from "~/helpers/query/useDateRange";
 
-import fetchMasterRecords from '@/helpers/fetch/fetchMasterRecords'
+import fetchMasterRecords from "@/helpers/fetch/fetchMasterRecords";
 
-import { Message } from '~/interfaces/messages'
-import { MasterRecord, MasterRecordStatistics } from '~/interfaces/masterrecord'
+import { Message } from "~/interfaces/messages";
+import { MasterRecord, MasterRecordStatistics } from "~/interfaces/masterrecord";
 
 export default defineComponent({
   props: {
@@ -66,16 +66,16 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { page, total, size } = usePagination()
-    const { makeDateRange } = useDateRange()
-    const { orderAscending, orderBy, toggleOrder } = useSortBy()
-    const { fetchMasterRecordMessagesPage } = fetchMasterRecords()
+    const { page, total, size } = usePagination();
+    const { makeDateRange } = useDateRange();
+    const { orderAscending, orderBy, toggleOrder } = useSortBy();
+    const { fetchMasterRecordMessagesPage } = fetchMasterRecords();
 
     // Set initial date dateRange
-    const dateRange = makeDateRange(nowString(-365), nowString(0), true)
+    const dateRange = makeDateRange(nowString(-365), nowString(0), true);
 
     // Data refs
-    const messages = ref<Message[]>()
+    const messages = ref<Message[]>();
 
     // Data fetching
 
@@ -88,17 +88,17 @@ export default defineComponent({
         [], // Status filter
         dateRange.value.start,
         dateRange.value.end
-      )
+      );
 
-      messages.value = messagesPage.items
-      total.value = messagesPage.total
-      page.value = messagesPage.page
-      size.value = messagesPage.size
+      messages.value = messagesPage.items;
+      total.value = messagesPage.total;
+      page.value = messagesPage.page;
+      size.value = messagesPage.size;
     }
 
     onMounted(() => {
-      fetchMessages()
-    })
+      fetchMessages();
+    });
 
     watch(
       [
@@ -107,9 +107,9 @@ export default defineComponent({
         () => JSON.stringify(dateRange), // Stringify to watch for actual value changes
       ],
       () => {
-        fetchMessages()
+        fetchMessages();
       }
-    )
+    );
 
     return {
       page,
@@ -120,7 +120,7 @@ export default defineComponent({
       orderAscending,
       orderBy,
       toggleOrder,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/masterrecords/index.vue
+++ b/pages/masterrecords/index.vue
@@ -57,26 +57,26 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { MasterRecord } from '@/interfaces/masterrecord'
-import usePagination from '~/helpers/query/usePagination'
+import { MasterRecord } from "@/interfaces/masterrecord";
+import usePagination from "~/helpers/query/usePagination";
 
-import useUserPrefs from '~/helpers/useUserPrefs'
-import useRecordSearch from '~/helpers/query/useRecordSearch'
+import useUserPrefs from "~/helpers/useUserPrefs";
+import useRecordSearch from "~/helpers/query/useRecordSearch";
 
-import fetchSearchResults from '~/helpers/fetch/fetchSearchResults'
+import fetchSearchResults from "~/helpers/fetch/fetchSearchResults";
 
 export default defineComponent({
   setup() {
-    const { page, total, size } = usePagination()
-    const { showUKRDC } = useUserPrefs()
-    const { searchQueryIsPopulated, searchboxString, searchSubmit, apiQueryString } = useRecordSearch()
-    const { fetchSearchResultsPage, searchInProgress } = fetchSearchResults()
+    const { page, total, size } = usePagination();
+    const { showUKRDC } = useUserPrefs();
+    const { searchQueryIsPopulated, searchboxString, searchSubmit, apiQueryString } = useRecordSearch();
+    const { fetchSearchResultsPage, searchInProgress } = fetchSearchResults();
 
     // Data refs
 
-    const masterrecords = ref([] as MasterRecord[])
+    const masterrecords = ref([] as MasterRecord[]);
 
     // Data fetching
 
@@ -87,22 +87,22 @@ export default defineComponent({
           page.value || 1,
           size.value,
           showUKRDC.value
-        )
+        );
 
-        masterrecords.value = resultsPage.items
-        page.value = resultsPage.page
-        total.value = resultsPage.total
-        size.value = resultsPage.size
+        masterrecords.value = resultsPage.items;
+        page.value = resultsPage.page;
+        total.value = resultsPage.total;
+        size.value = resultsPage.size;
       }
     }
 
     onMounted(() => {
-      getResults()
-    })
+      getResults();
+    });
 
     watch([apiQueryString, page, showUKRDC], () => {
-      getResults()
-    })
+      getResults();
+    });
 
     return {
       masterrecords,
@@ -114,10 +114,10 @@ export default defineComponent({
       page,
       size,
       total,
-    }
+    };
   },
   head: {
-    title: 'Master Records',
+    title: "Master Records",
   },
-})
+});
 </script>

--- a/pages/messages/_id.vue
+++ b/pages/messages/_id.vue
@@ -3,7 +3,7 @@
     <div class="mb-6 flex items-end gap-4">
       <div class="flex-grow">
         <TextH1 v-if="message">
-          {{ message.msgStatus === 'ERROR' ? 'Error' : 'Message' }} {{ message.id }} from {{ message.facility }}
+          {{ message.msgStatus === "ERROR" ? "Error" : "Message" }} {{ message.id }} from {{ message.facility }}
         </TextH1>
         <SkeleText v-else class="mb-2 h-8 w-1/4" />
         <TextL1 v-if="message" class="line-clamp-1">
@@ -18,48 +18,48 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useMeta, useRoute } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useMeta, useRoute } from "@nuxtjs/composition-api";
 
-import { Message } from '@/interfaces/messages'
+import { Message } from "@/interfaces/messages";
 
-import { MessageSummary } from '@/helpers/utils/messageUtils'
+import { MessageSummary } from "@/helpers/utils/messageUtils";
 
-import fetchMessages from '~/helpers/fetch/fetchMessages'
+import fetchMessages from "~/helpers/fetch/fetchMessages";
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-    const { fetchMessage } = fetchMessages()
+    const route = useRoute();
+    const { fetchMessage } = fetchMessages();
 
     // Head
 
-    const { title } = useMeta()
-    title.value = `Error ${route.value.params.id}`
+    const { title } = useMeta();
+    title.value = `Error ${route.value.params.id}`;
 
     // Data refs
 
-    const message = ref<Message>()
+    const message = ref<Message>();
 
     const messageSummary = computed(() => {
       if (message.value) {
-        return MessageSummary(message.value)
+        return MessageSummary(message.value);
       }
-      return ''
-    })
+      return "";
+    });
 
     // Data fetching
 
     onMounted(async () => {
-      message.value = await fetchMessage(route.value.params.id)
-    })
+      message.value = await fetchMessage(route.value.params.id);
+    });
 
     return {
       message,
       messageSummary,
-    }
+    };
   },
   head: {
-    title: 'Message',
+    title: "Message",
   },
-})
+});
 </script>

--- a/pages/messages/_id/index.vue
+++ b/pages/messages/_id/index.vue
@@ -15,7 +15,7 @@
           </GenericDi>
           <GenericDi>
             <TextDt>Recieved</TextDt>
-            <TextDd v-if="message"> {{ message.received ? formatDate(message.received) : 'Unknown' }}</TextDd>
+            <TextDd v-if="message"> {{ message.received ? formatDate(message.received) : "Unknown" }}</TextDd>
             <SkeleText v-else class="h-6 w-full" />
           </GenericDi>
           <GenericDi>
@@ -106,17 +106,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { Message } from '@/interfaces/messages'
-import { ChannelMessage } from '~/interfaces/mirth'
-import { WorkItem } from '~/interfaces/workitem'
-import { MasterRecord } from '~/interfaces/masterrecord'
+import { Message } from "@/interfaces/messages";
+import { ChannelMessage } from "~/interfaces/mirth";
+import { WorkItem } from "~/interfaces/workitem";
+import { MasterRecord } from "~/interfaces/masterrecord";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import fetchMessages from '~/helpers/fetch/fetchMessages'
-import usePermissions from '~/helpers/usePermissions'
+import fetchMessages from "~/helpers/fetch/fetchMessages";
+import usePermissions from "~/helpers/usePermissions";
 
 export default defineComponent({
   props: {
@@ -126,44 +126,44 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { hasPermission } = usePermissions()
+    const { hasPermission } = usePermissions();
     const {
       fetchMessageMasterRecords,
       fetchMessageWorkItems,
       fetchMessageMirth,
       downloadMessageSource,
       downloadSourceInProgress,
-    } = fetchMessages()
+    } = fetchMessages();
 
     // Data refs
-    const mirthMessage = ref<ChannelMessage | null | undefined>(undefined)
-    const workItems = ref([] as WorkItem[])
-    const masterRecords = ref([] as MasterRecord[])
+    const mirthMessage = ref<ChannelMessage | null | undefined>(undefined);
+    const workItems = ref([] as WorkItem[]);
+    const masterRecords = ref([] as MasterRecord[]);
 
     // Data fetching
 
     async function getMessageData() {
       // Get auxilalry record data
-      if (hasPermission('ukrdc:records:read')) {
-        masterRecords.value = await fetchMessageMasterRecords(props.message)
+      if (hasPermission("ukrdc:records:read")) {
+        masterRecords.value = await fetchMessageMasterRecords(props.message);
       }
-      if (hasPermission('ukrdc:workitems:read')) {
-        workItems.value = await fetchMessageWorkItems(props.message)
+      if (hasPermission("ukrdc:workitems:read")) {
+        workItems.value = await fetchMessageWorkItems(props.message);
       }
 
       // Conditionally get the Mirth message data
-      if (hasPermission('ukrdc:mirth:read')) {
+      if (hasPermission("ukrdc:mirth:read")) {
         try {
-          mirthMessage.value = await fetchMessageMirth(props.message)
+          mirthMessage.value = await fetchMessageMirth(props.message);
         } catch (e) {
-          mirthMessage.value = null
+          mirthMessage.value = null;
         }
       }
     }
 
     onMounted(() => {
-      getMessageData()
-    })
+      getMessageData();
+    });
 
     return {
       masterRecords,
@@ -173,7 +173,7 @@ export default defineComponent({
       downloadMessageSource,
       downloadSourceInProgress,
       hasPermission,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/messages/_id/source.vue
+++ b/pages/messages/_id/source.vue
@@ -16,10 +16,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
-import fetchMessages from '~/helpers/fetch/fetchMessages'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
+import fetchMessages from "~/helpers/fetch/fetchMessages";
 
-import { ErrorSource, Message } from '~/interfaces/messages'
+import { ErrorSource, Message } from "~/interfaces/messages";
 
 export default defineComponent({
   props: {
@@ -29,24 +29,24 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { fetchMessageSource, fetchSourceInProgress } = fetchMessages()
+    const { fetchMessageSource, fetchSourceInProgress } = fetchMessages();
 
-    const source = ref<ErrorSource>()
-    const error = ref<string>()
+    const source = ref<ErrorSource>();
+    const error = ref<string>();
 
     onMounted(async () => {
       try {
-        source.value = await fetchMessageSource(props.message)
+        source.value = await fetchMessageSource(props.message);
       } catch (e: any) {
-        error.value = e.response.data.detail
+        error.value = e.response.data.detail;
       }
-    })
+    });
 
     return {
       fetchSourceInProgress,
       source,
       error,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -73,46 +73,46 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { nowString } from '@/helpers/utils/dateUtils'
-import { Message } from '@/interfaces/messages'
-import usePagination from '~/helpers/query/usePagination'
-import useDateRange from '~/helpers/query/useDateRange'
+import { nowString } from "@/helpers/utils/dateUtils";
+import { Message } from "@/interfaces/messages";
+import usePagination from "~/helpers/query/usePagination";
+import useDateRange from "~/helpers/query/useDateRange";
 
-import usePermissions from '~/helpers/usePermissions'
-import useFacilities from '~/helpers/useFacilities'
-import useQuery from '~/helpers/query/useQuery'
-import useSortBy from '~/helpers/query/useSortBy'
+import usePermissions from "~/helpers/usePermissions";
+import useFacilities from "~/helpers/useFacilities";
+import useQuery from "~/helpers/query/useQuery";
+import useSortBy from "~/helpers/query/useSortBy";
 
-import fetchMessages from '~/helpers/fetch/fetchMessages'
+import fetchMessages from "~/helpers/fetch/fetchMessages";
 
 export default defineComponent({
   setup() {
-    const { page, total, size } = usePagination()
-    const { makeDateRange } = useDateRange()
-    const { stringQuery, arrayQuery } = useQuery()
-    const { facilities, facilityIds, facilityLabels, selectedFacility } = useFacilities()
-    const { orderAscending, orderBy, toggleOrder } = useSortBy()
-    const { fetchMessagesPage } = fetchMessages()
-    const { isAdmin } = usePermissions()
+    const { page, total, size } = usePagination();
+    const { makeDateRange } = useDateRange();
+    const { stringQuery, arrayQuery } = useQuery();
+    const { facilities, facilityIds, facilityLabels, selectedFacility } = useFacilities();
+    const { orderAscending, orderBy, toggleOrder } = useSortBy();
+    const { fetchMessagesPage } = fetchMessages();
+    const { isAdmin } = usePermissions();
 
     // Set up URL query params for additional filters
-    const nationalId = stringQuery('nationalid', null, true, true)
-    const nationalIdSearchString = ref<string | null>(null)
+    const nationalId = stringQuery("nationalid", null, true, true);
+    const nationalIdSearchString = ref<string | null>(null);
 
     // Set initial date dateRange
-    const dateRange = makeDateRange(isAdmin ? nowString(-30) : nowString(-365), nowString(0), true)
+    const dateRange = makeDateRange(isAdmin ? nowString(-30) : nowString(-365), nowString(0), true);
 
     // Data refs
-    const messages = ref<Message[]>()
-    const statuses = arrayQuery('status', ['ERROR'], true, true)
+    const messages = ref<Message[]>();
+    const statuses = arrayQuery("status", ["ERROR"], true, true);
 
-    const fetchInProgress = ref(false)
+    const fetchInProgress = ref(false);
 
     // Data fetching
     async function getMessages() {
-      fetchInProgress.value = true
+      fetchInProgress.value = true;
 
       const messagesPage = await fetchMessagesPage(
         page.value || 1,
@@ -123,18 +123,18 @@ export default defineComponent({
         dateRange.value.end,
         selectedFacility.value,
         nationalId.value
-      )
-      messages.value = messagesPage.items
-      total.value = messagesPage.total
-      page.value = messagesPage.page
-      size.value = messagesPage.size
+      );
+      messages.value = messagesPage.items;
+      total.value = messagesPage.total;
+      page.value = messagesPage.page;
+      size.value = messagesPage.size;
 
-      fetchInProgress.value = false
+      fetchInProgress.value = false;
     }
 
     onMounted(() => {
-      getMessages()
-    })
+      getMessages();
+    });
 
     watch(
       [
@@ -146,9 +146,9 @@ export default defineComponent({
         () => JSON.stringify(statuses), // Stringify to watch for actual value changes
       ],
       () => {
-        getMessages()
+        getMessages();
       }
-    )
+    );
 
     return {
       fetchInProgress,
@@ -167,11 +167,11 @@ export default defineComponent({
       orderAscending,
       orderBy,
       toggleOrder,
-    }
+    };
   },
 
   head: {
-    title: 'Data Files',
+    title: "Data Files",
   },
-})
+});
 </script>

--- a/pages/mirth/index.vue
+++ b/pages/mirth/index.vue
@@ -23,7 +23,7 @@
                 {{ item.name }}
               </TextH3>
               <TextL1> Rev. {{ item.revision }} </TextL1>
-              <TextP> {{ item.statistics ? item.statistics.received : 'Unknown' }} received </TextP>
+              <TextP> {{ item.statistics ? item.statistics.received : "Unknown" }} received </TextP>
               <span
                 v-if="item.statistics && item.statistics.error === 0"
                 class="mt-2 inline-block rounded-sm bg-green-100 px-2 py-0.5 text-sm font-medium text-green-800"
@@ -43,30 +43,30 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
-import fetchMirth from '~/helpers/fetch/fetchMirth'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
+import fetchMirth from "~/helpers/fetch/fetchMirth";
 
-import { ChannelGroup } from '@/interfaces/mirth'
+import { ChannelGroup } from "@/interfaces/mirth";
 
 export default defineComponent({
   setup() {
-    const { fetchMirthGroups } = fetchMirth()
+    const { fetchMirthGroups } = fetchMirth();
 
     // Data refs
-    const mirthGroups = ref<ChannelGroup[]>()
+    const mirthGroups = ref<ChannelGroup[]>();
 
     // Data fetching
     onMounted(async () => {
-      mirthGroups.value = await fetchMirthGroups()
-    })
+      mirthGroups.value = await fetchMirthGroups();
+    });
 
     return {
       mirthGroups,
-    }
+    };
   },
 
   head: {
-    title: 'Mirth Channels',
+    title: "Mirth Channels",
   },
-})
+});
 </script>

--- a/pages/mirth/messages/_channel/_id.vue
+++ b/pages/mirth/messages/_channel/_id.vue
@@ -13,35 +13,35 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, useMeta, useRoute } from '@nuxtjs/composition-api'
-import fetchMirth from '~/helpers/fetch/fetchMirth'
+import { defineComponent, onMounted, ref, useMeta, useRoute } from "@nuxtjs/composition-api";
+import fetchMirth from "~/helpers/fetch/fetchMirth";
 
-import { ChannelMessage } from '@/interfaces/mirth'
+import { ChannelMessage } from "@/interfaces/mirth";
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-    const { fetchMirthMessage } = fetchMirth()
+    const route = useRoute();
+    const { fetchMirthMessage } = fetchMirth();
 
     // Head
 
-    const { title } = useMeta()
-    title.value = `Mirth message ${route.value.params.id}`
+    const { title } = useMeta();
+    title.value = `Mirth message ${route.value.params.id}`;
 
     // Data refs
-    const message = ref<ChannelMessage>()
+    const message = ref<ChannelMessage>();
 
     // Data fetching
     onMounted(async () => {
-      message.value = await fetchMirthMessage(route.value.params.channel, route.value.params.id)
-    })
+      message.value = await fetchMirthMessage(route.value.params.channel, route.value.params.id);
+    });
 
     return {
       message,
-    }
+    };
   },
   head: {
-    title: 'Mirth Message',
+    title: "Mirth Message",
   },
-})
+});
 </script>

--- a/pages/mirth/messages/_channel/_id/_orderId.vue
+++ b/pages/mirth/messages/_channel/_id/_orderId.vue
@@ -69,16 +69,16 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, useRoute, watch } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref, useRoute, watch } from "@nuxtjs/composition-api";
 
-import { ChannelMessage, ConnectorMessage, ConnectorMessageData, MetaDataMap } from '@/interfaces/mirth'
-import { connectorMessageError } from '~/helpers/utils/mirthUtils'
+import { ChannelMessage, ConnectorMessage, ConnectorMessageData, MetaDataMap } from "@/interfaces/mirth";
+import { connectorMessageError } from "~/helpers/utils/mirthUtils";
 
 interface ConnectorMessageDataTabs {
-  raw: ConnectorMessageData
-  encoded: ConnectorMessageData
-  sent: ConnectorMessageData
-  response: ConnectorMessageData
+  raw: ConnectorMessageData;
+  encoded: ConnectorMessageData;
+  sent: ConnectorMessageData;
+  response: ConnectorMessageData;
 }
 
 export default defineComponent({
@@ -89,57 +89,57 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const route = useRoute()
+    const route = useRoute();
 
     // Data refs
     const connectorMessage = computed(() => {
-      const orderId = parseInt(route.value.params.orderId)
-      return props.message.connectorMessages[orderId] as ConnectorMessage
-    })
-    const formatconnectorMessage = ref(true)
+      const orderId = parseInt(route.value.params.orderId);
+      return props.message.connectorMessages[orderId] as ConnectorMessage;
+    });
+    const formatconnectorMessage = ref(true);
 
     // Manage viewer tabs
-    const currentTab = ref('metadata')
+    const currentTab = ref("metadata");
 
     const tabs = computed(() => {
-      return ['metadata'].concat(Object.keys(availableconnectorMessageData.value))
-    })
+      return ["metadata"].concat(Object.keys(availableconnectorMessageData.value));
+    });
 
     watch(connectorMessage, () => {
-      currentTab.value = tabs.value[0]
-    })
+      currentTab.value = tabs.value[0];
+    });
 
     // Handle connectorMessage and metadata
     const availableconnectorMessageData = computed<ConnectorMessageDataTabs>(() => {
-      const tabs = {} as ConnectorMessageDataTabs
+      const tabs = {} as ConnectorMessageDataTabs;
       if (connectorMessage.value) {
         if (connectorMessage.value.raw !== null) {
-          tabs.raw = connectorMessage.value.raw
+          tabs.raw = connectorMessage.value.raw;
         }
         if (connectorMessage.value.encoded !== null) {
-          tabs.encoded = connectorMessage.value.encoded
+          tabs.encoded = connectorMessage.value.encoded;
         }
         if (connectorMessage.value.sent !== null) {
-          tabs.sent = connectorMessage.value.sent
+          tabs.sent = connectorMessage.value.sent;
         }
         if (connectorMessage.value.response !== null) {
-          tabs.response = connectorMessage.value.response
+          tabs.response = connectorMessage.value.response;
         }
       }
-      return tabs
-    })
+      return tabs;
+    });
 
     const nonNullMetadata = computed<MetaDataMap>(() => {
       if (connectorMessage.value?.metaDataMap) {
-        return Object.fromEntries(Object.entries(connectorMessage.value.metaDataMap).filter(([_, v]) => v != null))
+        return Object.fromEntries(Object.entries(connectorMessage.value.metaDataMap).filter(([_, v]) => v != null));
       } else {
-        return {}
+        return {};
       }
-    })
+    });
 
     const errorMessage = computed(() => {
-      return connectorMessage.value ? connectorMessageError(connectorMessage.value) : null
-    })
+      return connectorMessage.value ? connectorMessageError(connectorMessage.value) : null;
+    });
 
     return {
       connectorMessage,
@@ -149,10 +149,10 @@ export default defineComponent({
       availableconnectorMessageData,
       formatconnectorMessage,
       errorMessage,
-    }
+    };
   },
   head: {
-    title: 'Mirth Message',
+    title: "Mirth Message",
   },
-})
+});
 </script>

--- a/pages/mirth/messages/_channel/_id/index.vue
+++ b/pages/mirth/messages/_channel/_id/index.vue
@@ -6,9 +6,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { ChannelMessage } from '@/interfaces/mirth'
+import { ChannelMessage } from "@/interfaces/mirth";
 
 export default defineComponent({
   props: {
@@ -18,10 +18,10 @@ export default defineComponent({
     },
   },
   setup() {
-    return {}
+    return {};
   },
   head: {
-    title: 'Mirth Message',
+    title: "Mirth Message",
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid.vue
+++ b/pages/patientrecords/_pid.vue
@@ -25,97 +25,106 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useMeta, useRoute, useRouter, watch } from '@nuxtjs/composition-api'
+import {
+  computed,
+  defineComponent,
+  onMounted,
+  ref,
+  useMeta,
+  useRoute,
+  useRouter,
+  watch,
+} from "@nuxtjs/composition-api";
 
-import { PatientRecord, PatientRecordSummary } from '@/interfaces/patientrecord'
-import { TabItem } from '@/interfaces/tabs'
+import { PatientRecord, PatientRecordSummary } from "@/interfaces/patientrecord";
+import { TabItem } from "@/interfaces/tabs";
 
-import { firstForename, firstSurname, isMembership } from '@/helpers/utils/recordUtils'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { firstForename, firstSurname, isMembership } from "@/helpers/utils/recordUtils";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   setup() {
-    const route = useRoute()
-    const router = useRouter()
-    const { fetchPatientRecord, fetchPatientRecordRelated } = fetchPatientRecords()
+    const route = useRoute();
+    const router = useRouter();
+    const { fetchPatientRecord, fetchPatientRecordRelated } = fetchPatientRecords();
 
     // Head
-    const { title } = useMeta()
-    title.value = `Record ${route.value.params.pid}`
+    const { title } = useMeta();
+    title.value = `Record ${route.value.params.pid}`;
 
     // Data refs
 
-    const record = ref<PatientRecord>()
-    const related = ref<PatientRecordSummary[]>()
+    const record = ref<PatientRecord>();
+    const related = ref<PatientRecordSummary[]>();
 
     // Data fetching
 
     async function getRecord() {
-      record.value = await fetchPatientRecord(route.value.params.pid)
-      related.value = await fetchPatientRecordRelated(record.value)
+      record.value = await fetchPatientRecord(route.value.params.pid);
+      related.value = await fetchPatientRecordRelated(record.value);
     }
 
     onMounted(() => {
-      getRecord()
-    })
+      getRecord();
+    });
 
     // PID Switcher UI
 
     const relatedDataRecords = computed<PatientRecordSummary[]>(() => {
       if (related.value) {
-        return related.value.filter((record) => !isMembership(record))
+        return related.value.filter((record) => !isMembership(record));
       }
-      return []
-    })
+      return [];
+    });
 
-    const selectedPid = ref(route.value.params.pid)
+    const selectedPid = ref(route.value.params.pid);
 
     watch(selectedPid, (value: string) => {
-      router.push({ name: route.value.name!, params: { pid: value } })
-    })
+      router.push({ name: route.value.name!, params: { pid: value } });
+    });
 
     // Dynamic UI elements
 
     const forename = computed(() => {
-      return record.value ? firstForename(record.value) : ''
-    })
+      return record.value ? firstForename(record.value) : "";
+    });
 
     const surname = computed(() => {
-      return record.value ? firstSurname(record.value) : ''
-    })
+      return record.value ? firstSurname(record.value) : "";
+    });
 
     // Navigation
 
     const tabs = [
       {
-        name: 'Overview',
+        name: "Overview",
         href: `/patientrecords/${route.value.params.pid}`,
       },
       {
-        name: 'Medications',
+        name: "Medications",
         href: `/patientrecords/${route.value.params.pid}/medications`,
       },
       {
-        name: 'Treatments',
+        name: "Treatments",
         href: `/patientrecords/${route.value.params.pid}/treatments`,
       },
       {
-        name: 'Results',
+        name: "Results",
         href: `/patientrecords/${route.value.params.pid}/results`,
       },
       {
-        name: 'Observations',
+        name: "Observations",
         href: `/patientrecords/${route.value.params.pid}/observations`,
       },
       {
-        name: 'Documents',
+        name: "Documents",
         href: `/patientrecords/${route.value.params.pid}/documents`,
       },
       {
-        name: 'Surveys',
+        name: "Surveys",
         href: `/patientrecords/${route.value.params.pid}/surveys`,
       },
-    ] as TabItem[]
+    ] as TabItem[];
 
     return {
       record,
@@ -125,10 +134,10 @@ export default defineComponent({
       forename,
       surname,
       tabs,
-    }
+    };
   },
   head: {
-    title: 'Patient Record',
+    title: "Patient Record",
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/documents/_docid.vue
+++ b/pages/patientrecords/_pid/documents/_docid.vue
@@ -5,7 +5,7 @@
     <GenericCard>
       <GenericCardHeader>
         <div class="mb-1">
-          <TextH2 v-if="patientDocument"> {{ patientDocument.documentname || 'Unnamed Document' }} </TextH2>
+          <TextH2 v-if="patientDocument"> {{ patientDocument.documentname || "Unnamed Document" }} </TextH2>
           <SkeleText v-else class="h-6 w-1/2" />
         </div>
         <div>
@@ -18,21 +18,21 @@
           <GenericDi>
             <TextDt>Entered At</TextDt>
             <TextDd v-if="patientDocument">
-              {{ patientDocument.enteredatdesc || patientDocument.enteredatcode || 'Unknown Facility' }}
+              {{ patientDocument.enteredatdesc || patientDocument.enteredatcode || "Unknown Facility" }}
             </TextDd>
             <SkeleText v-else class="h-6 w-1/2" />
           </GenericDi>
           <GenericDi>
             <TextDt>Entered By</TextDt>
             <TextDd v-if="patientDocument">{{
-              patientDocument.enteredbydesc || patientDocument.enteredbycode || 'Unknown Person'
+              patientDocument.enteredbydesc || patientDocument.enteredbycode || "Unknown Person"
             }}</TextDd>
             <SkeleText v-else class="h-6 w-1/2" />
           </GenericDi>
           <GenericDi>
             <TextDt>Clinician:</TextDt>
             <TextDd v-if="patientDocument">
-              {{ patientDocument.cliniciandesc || patientDocument.cliniciancode || 'Unknown Clinician' }}
+              {{ patientDocument.cliniciandesc || patientDocument.cliniciancode || "Unknown Clinician" }}
             </TextDd>
             <SkeleText v-else class="h-6 w-1/2" />
           </GenericDi>
@@ -78,13 +78,13 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useRoute } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useRoute } from "@nuxtjs/composition-api";
 
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
-import { formatDate } from '@/helpers/utils/dateUtils'
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { PatientRecord } from '@/interfaces/patientrecord'
-import { PatientDocument } from '~/interfaces/document'
+import { PatientRecord } from "@/interfaces/patientrecord";
+import { PatientDocument } from "~/interfaces/document";
 
 export default defineComponent({
   props: {
@@ -96,24 +96,24 @@ export default defineComponent({
 
   setup(props) {
     const { fetchPatientRecordDocument, downloadPatientRecordDocument, documentDownloadInProgress } =
-      fetchPatientRecords()
-    const route = useRoute()
+      fetchPatientRecords();
+    const route = useRoute();
 
     // Data refs
-    const patientDocument = ref<PatientDocument>()
+    const patientDocument = ref<PatientDocument>();
 
     // Computed properties
     const filename = computed(() => {
       if (!patientDocument.value) {
-        return undefined
+        return undefined;
       }
-      return patientDocument.value.filename || `${patientDocument.value.documentname}.txt`
-    })
+      return patientDocument.value.filename || `${patientDocument.value.documentname}.txt`;
+    });
 
     // Data fetching
     onMounted(async () => {
-      patientDocument.value = await fetchPatientRecordDocument(props.record, route.value.params.docid)
-    })
+      patientDocument.value = await fetchPatientRecordDocument(props.record, route.value.params.docid);
+    });
 
     return {
       patientDocument,
@@ -121,7 +121,7 @@ export default defineComponent({
       formatDate,
       downloadPatientRecordDocument,
       documentDownloadInProgress,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/documents/index.vue
+++ b/pages/patientrecords/_pid/documents/index.vue
@@ -29,17 +29,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { PatientRecord } from '@/interfaces/patientrecord'
-import { PatientDocumentSummary } from '@/interfaces/document'
+import { PatientRecord } from "@/interfaces/patientrecord";
+import { PatientDocumentSummary } from "@/interfaces/document";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import usePagination from '~/helpers/query/usePagination'
-import useDateRange from '~/helpers/query/useDateRange'
+import usePagination from "~/helpers/query/usePagination";
+import useDateRange from "~/helpers/query/useDateRange";
 
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   props: {
@@ -49,34 +49,34 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { page, total, size } = usePagination()
-    const { makeDateRange } = useDateRange()
-    const { fetchPatientRecordDocumentsPage } = fetchPatientRecords()
+    const { page, total, size } = usePagination();
+    const { makeDateRange } = useDateRange();
+    const { fetchPatientRecordDocumentsPage } = fetchPatientRecords();
 
     // Set initial date dateRange
-    const dateRange = makeDateRange(null, null, true, false)
+    const dateRange = makeDateRange(null, null, true, false);
 
     // Data refs
 
-    const documents = ref<PatientDocumentSummary[]>()
+    const documents = ref<PatientDocumentSummary[]>();
 
     // Data fetching
 
     async function getDocuments() {
-      const documentsPage = await fetchPatientRecordDocumentsPage(props.record, page.value || 1, size.value)
-      documents.value = documentsPage.items
-      total.value = documentsPage.total
-      page.value = documentsPage.page
-      size.value = documentsPage.size
+      const documentsPage = await fetchPatientRecordDocumentsPage(props.record, page.value || 1, size.value);
+      documents.value = documentsPage.items;
+      total.value = documentsPage.total;
+      page.value = documentsPage.page;
+      size.value = documentsPage.size;
     }
 
     onMounted(() => {
-      getDocuments()
-    })
+      getDocuments();
+    });
 
     watch(page, () => {
-      getDocuments()
-    })
+      getDocuments();
+    });
 
     return {
       page,
@@ -85,9 +85,9 @@ export default defineComponent({
       dateRange,
       documents,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/pages/patientrecords/_pid/index.vue
+++ b/pages/patientrecords/_pid/index.vue
@@ -41,13 +41,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
-import { isEmptyObject } from '@/helpers/utils/objectUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
+import { isEmptyObject } from "@/helpers/utils/objectUtils";
 
-import { PatientRecord } from '@/interfaces/patientrecord'
+import { PatientRecord } from "@/interfaces/patientrecord";
 
 export default defineComponent({
   props: {
@@ -62,7 +62,7 @@ export default defineComponent({
       formatDate,
       formatGender,
       isEmptyObject,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/laborders.vue
+++ b/pages/patientrecords/_pid/laborders.vue
@@ -31,14 +31,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { LabOrderShort } from '@/interfaces/laborder'
-import { PatientRecord } from '@/interfaces/patientrecord'
-import usePagination from '~/helpers/query/usePagination'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { LabOrderShort } from "@/interfaces/laborder";
+import { PatientRecord } from "@/interfaces/patientrecord";
+import usePagination from "~/helpers/query/usePagination";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   props: {
@@ -49,32 +49,32 @@ export default defineComponent({
   },
 
   setup(props) {
-    const { page, total, size } = usePagination()
-    const { fetchPatientRecordLabOrdersPage } = fetchPatientRecords()
+    const { page, total, size } = usePagination();
+    const { fetchPatientRecordLabOrdersPage } = fetchPatientRecords();
 
     // Data refs
-    size.value = 18 // Fetch a multiple of our row length
-    const orders = ref([] as LabOrderShort[])
+    size.value = 18; // Fetch a multiple of our row length
+    const orders = ref([] as LabOrderShort[]);
 
     // Data fetching
 
     async function fetchOrders() {
-      const ordersPage = await fetchPatientRecordLabOrdersPage(props.record, page.value || 1, size.value)
-      orders.value = ordersPage.items
-      total.value = ordersPage.total
-      page.value = ordersPage.page
-      size.value = ordersPage.size
+      const ordersPage = await fetchPatientRecordLabOrdersPage(props.record, page.value || 1, size.value);
+      orders.value = ordersPage.items;
+      total.value = ordersPage.total;
+      page.value = ordersPage.page;
+      size.value = ordersPage.size;
     }
 
     onMounted(() => {
-      fetchOrders()
-    })
+      fetchOrders();
+    });
 
     watch(page, () => {
-      fetchOrders()
-    })
+      fetchOrders();
+    });
 
-    return { page, size, total, orders, formatDate }
+    return { page, size, total, orders, formatDate };
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/medications.vue
+++ b/pages/patientrecords/_pid/medications.vue
@@ -25,11 +25,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { Medication } from '@/interfaces/medication'
-import { PatientRecord } from '@/interfaces/patientrecord'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { Medication } from "@/interfaces/medication";
+import { PatientRecord } from "@/interfaces/patientrecord";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   props: {
@@ -40,36 +40,36 @@ export default defineComponent({
   },
 
   setup(props) {
-    const { fetchPatientRecordMedications } = fetchPatientRecords()
+    const { fetchPatientRecordMedications } = fetchPatientRecords();
 
     // Data refs
-    const medications = ref<Medication[]>()
+    const medications = ref<Medication[]>();
 
     // Data fetching
     onMounted(async () => {
-      medications.value = await fetchPatientRecordMedications(props.record)
-    })
+      medications.value = await fetchPatientRecordMedications(props.record);
+    });
 
     // Split active and inactive medications
 
     const activeMedications = computed(() => {
-      if (!medications.value) return []
+      if (!medications.value) return [];
       return medications.value?.filter(function (item: Medication) {
-        return item.toTime === null
-      })
-    })
+        return item.toTime === null;
+      });
+    });
     const inactiveMedications = computed(() => {
-      if (!medications.value) return []
+      if (!medications.value) return [];
       return medications.value?.filter(function (item: Medication) {
-        return item.toTime !== null
-      })
-    })
+        return item.toTime !== null;
+      });
+    });
 
     return {
       activeMedications,
       inactiveMedications,
       medications,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/observations.vue
+++ b/pages/patientrecords/_pid/observations.vue
@@ -61,16 +61,16 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useRoute, useRouter, watch } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useRoute, useRouter, watch } from "@nuxtjs/composition-api";
 
-import usePagination from '~/helpers/query/usePagination'
+import usePagination from "~/helpers/query/usePagination";
 
-import { arrayQuery } from '@/helpers/utils/queryUtils'
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { arrayQuery } from "@/helpers/utils/queryUtils";
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { Observation } from '@/interfaces/observation'
-import { PatientRecord } from '@/interfaces/patientrecord'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { Observation } from "@/interfaces/observation";
+import { PatientRecord } from "@/interfaces/patientrecord";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   props: {
@@ -81,17 +81,17 @@ export default defineComponent({
   },
 
   setup(props) {
-    const route = useRoute()
-    const router = useRouter()
-    const { page, total, size } = usePagination()
-    const { fetchPatientRecordObservationsPage, fetchPatientRecordObservationCodes } = fetchPatientRecords()
+    const route = useRoute();
+    const router = useRouter();
+    const { page, total, size } = usePagination();
+    const { fetchPatientRecordObservationsPage, fetchPatientRecordObservationCodes } = fetchPatientRecords();
 
     // Data refs
 
-    const observations = ref<Observation[]>()
+    const observations = ref<Observation[]>();
 
-    const availableCodes = ref([] as string[])
-    const selectedCodes = ref((arrayQuery(route.value.query.code) || []) as string[])
+    const availableCodes = ref([] as string[]);
+    const selectedCodes = ref((arrayQuery(route.value.query.code) || []) as string[]);
 
     // Data fetching
 
@@ -101,21 +101,21 @@ export default defineComponent({
         page.value || 1,
         size.value,
         selectedCodes.value
-      )
-      observations.value = observationsPage.items
-      total.value = observationsPage.total
-      page.value = observationsPage.page
-      size.value = observationsPage.size
+      );
+      observations.value = observationsPage.items;
+      total.value = observationsPage.total;
+      page.value = observationsPage.page;
+      size.value = observationsPage.size;
 
       // If we don't already have a list of available codes, fetch one
       if (availableCodes.value.length === 0) {
-        availableCodes.value = await fetchPatientRecordObservationCodes(props.record)
+        availableCodes.value = await fetchPatientRecordObservationCodes(props.record);
       }
     }
 
     onMounted(() => {
-      fetchObservations()
-    })
+      fetchObservations();
+    });
 
     watch(
       [
@@ -123,28 +123,28 @@ export default defineComponent({
         () => JSON.stringify(selectedCodes), // Stringify to watch for actual value changes
       ],
       () => {
-        fetchObservations()
+        fetchObservations();
       }
-    )
+    );
 
     // Observation code filter
 
     const selectedCodeString = computed({
-      get: () => selectedCodes.value[0] || '',
+      get: () => selectedCodes.value[0] || "",
       set: (newCode: string) => {
-        selectedCodes.value = [newCode]
+        selectedCodes.value = [newCode];
 
         // Reset page when we change the filter
         const newQuery = {
-          page: '1',
+          page: "1",
           code: selectedCodes.value,
-        }
+        };
         router.push({
           path: route.value.path,
           query: newQuery,
-        })
+        });
       },
-    })
+    });
 
     return {
       page,
@@ -154,7 +154,7 @@ export default defineComponent({
       availableCodes,
       selectedCodeString,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/results.vue
+++ b/pages/patientrecords/_pid/results.vue
@@ -94,19 +94,19 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useContext, watch } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useContext, watch } from "@nuxtjs/composition-api";
 
-import { PatientRecord } from '@/interfaces/patientrecord'
-import { LabOrder, ResultItem } from '@/interfaces/laborder'
+import { PatientRecord } from "@/interfaces/patientrecord";
+import { LabOrder, ResultItem } from "@/interfaces/laborder";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import usePagination from '~/helpers/query/usePagination'
-import useQuery from '~/helpers/query/useQuery'
-import useDateRange from '~/helpers/query/useDateRange'
+import usePagination from "~/helpers/query/usePagination";
+import useQuery from "~/helpers/query/useQuery";
+import useDateRange from "~/helpers/query/useDateRange";
 
-import fetchPatientRecords, { ResultService } from '~/helpers/fetch/fetchPatientRecords'
-import { modalInterface } from '~/interfaces/modal'
+import fetchPatientRecords, { ResultService } from "~/helpers/fetch/fetchPatientRecords";
+import { modalInterface } from "~/interfaces/modal";
 
 export default defineComponent({
   props: {
@@ -116,24 +116,24 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { $toast } = useContext()
-    const { page, total, size } = usePagination()
-    const { makeDateRange } = useDateRange()
-    const { stringQuery } = useQuery()
+    const { $toast } = useContext();
+    const { page, total, size } = usePagination();
+    const { makeDateRange } = useDateRange();
+    const { stringQuery } = useQuery();
     const {
       fetchPatientRecordResultsPage,
       fetchPatientRecordResultServices,
       deletePatientRecordResultItem,
       fetchPatientRecordLabOrder,
       deletePatientRecordLabOrder,
-    } = fetchPatientRecords()
+    } = fetchPatientRecords();
 
     // Set initial date dateRange
-    const dateRange = makeDateRange(null, null, true, false)
+    const dateRange = makeDateRange(null, null, true, false);
 
     // Data refs
 
-    const results = ref([] as ResultItem[])
+    const results = ref([] as ResultItem[]);
 
     // Data fetching
 
@@ -146,100 +146,100 @@ export default defineComponent({
         selectedOrderId.value,
         dateRange.value.start,
         dateRange.value.end
-      )
-      results.value = resultsPage.items
-      total.value = resultsPage.total
-      page.value = resultsPage.page
-      size.value = resultsPage.size
+      );
+      results.value = resultsPage.items;
+      total.value = resultsPage.total;
+      page.value = resultsPage.page;
+      size.value = resultsPage.size;
 
       // If we don't already have a list of available codes, fetch one
       if (availableServicesMap.value.length === 0) {
-        availableServicesMap.value = await fetchPatientRecordResultServices(props.record)
+        availableServicesMap.value = await fetchPatientRecordResultServices(props.record);
       }
     }
 
-    const selectedOrder = ref<LabOrder>()
+    const selectedOrder = ref<LabOrder>();
 
     async function fetchLabOrder() {
       if (selectedOrderId.value) {
-        selectedOrder.value = await fetchPatientRecordLabOrder(props.record, selectedOrderId.value)
+        selectedOrder.value = await fetchPatientRecordLabOrder(props.record, selectedOrderId.value);
       }
     }
 
     // Data deletion
 
-    const deleteResultAlert = ref<modalInterface>()
-    const deleteOrderAlert = ref<modalInterface>()
+    const deleteResultAlert = ref<modalInterface>();
+    const deleteOrderAlert = ref<modalInterface>();
 
-    const itemToDelete = ref<ResultItem | null>(null)
+    const itemToDelete = ref<ResultItem | null>(null);
 
     function showDeleteResultItemModal(item: ResultItem) {
-      itemToDelete.value = item
-      deleteResultAlert.value?.show()
+      itemToDelete.value = item;
+      deleteResultAlert.value?.show();
     }
 
     function cancelDeleteResultItem() {
-      itemToDelete.value = null
-      deleteResultAlert.value?.hide()
+      itemToDelete.value = null;
+      deleteResultAlert.value?.hide();
     }
 
     async function deleteResultItem() {
       if (itemToDelete.value) {
-        await deletePatientRecordResultItem(itemToDelete.value)
+        await deletePatientRecordResultItem(itemToDelete.value);
         $toast.show({
-          type: 'success',
-          title: 'Success',
-          message: 'Result Item deleted',
+          type: "success",
+          title: "Success",
+          message: "Result Item deleted",
           timeout: 10,
-          classTimeout: 'bg-green-600',
-        })
-        await fetchResults()
-        itemToDelete.value = null
-        deleteResultAlert.value?.hide()
+          classTimeout: "bg-green-600",
+        });
+        await fetchResults();
+        itemToDelete.value = null;
+        deleteResultAlert.value?.hide();
       }
     }
 
     async function deleteLabOrder() {
       if (selectedOrder.value) {
-        await deletePatientRecordLabOrder(selectedOrder.value)
+        await deletePatientRecordLabOrder(selectedOrder.value);
         $toast.show({
-          type: 'success',
-          title: 'Success',
-          message: 'Lab Order deleted',
+          type: "success",
+          title: "Success",
+          message: "Lab Order deleted",
           timeout: 10,
-          classTimeout: 'bg-green-600',
-        })
-        selectedOrderId.value = null
-        await fetchResults()
-        await fetchLabOrder()
-        deleteOrderAlert.value?.hide()
+          classTimeout: "bg-green-600",
+        });
+        selectedOrderId.value = null;
+        await fetchResults();
+        await fetchLabOrder();
+        deleteOrderAlert.value?.hide();
       }
     }
 
     // Result item services
 
-    const availableServicesMap = ref([] as ResultService[])
+    const availableServicesMap = ref([] as ResultService[]);
 
     const availableServicesIds = computed(() => {
-      return availableServicesMap.value.map(({ id }) => id)
-    })
+      return availableServicesMap.value.map(({ id }) => id);
+    });
 
     const availableServicesLabels = computed(() => {
-      return availableServicesMap.value.map(({ description }) => description)
-    })
+      return availableServicesMap.value.map(({ description }) => description);
+    });
 
-    const selectedService = stringQuery('service_id', null, true, true)
+    const selectedService = stringQuery("service_id", null, true, true);
 
     // Lab order filter
 
-    const selectedOrderId = stringQuery('order_id', null, true, true)
+    const selectedOrderId = stringQuery("order_id", null, true, true);
 
     // Data lifecycle
 
     onMounted(() => {
-      fetchResults()
-      fetchLabOrder()
-    })
+      fetchResults();
+      fetchLabOrder();
+    });
 
     watch(
       [
@@ -249,13 +249,13 @@ export default defineComponent({
         () => JSON.stringify(dateRange.value), // Stringify to watch for actual value changes
       ],
       () => {
-        fetchResults()
+        fetchResults();
       }
-    )
+    );
 
     watch(selectedOrderId, () => {
-      fetchLabOrder()
-    })
+      fetchLabOrder();
+    });
 
     return {
       page,
@@ -277,9 +277,9 @@ export default defineComponent({
       selectedOrderId,
       selectedOrder,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>
 
 <style scoped></style>

--- a/pages/patientrecords/_pid/surveys.vue
+++ b/pages/patientrecords/_pid/surveys.vue
@@ -18,8 +18,8 @@
           <p class="text-gray-500">Type: {{ item.surveytypecode }}</p>
           <p class="text-gray-500">
             Entered at
-            {{ item.enteredatcode ? item.enteredatcode : 'unknown location' }}
-            by {{ item.enteredbycode ? item.enteredbycode : 'unknown person' }}
+            {{ item.enteredatcode ? item.enteredatcode : "unknown location" }}
+            by {{ item.enteredbycode ? item.enteredbycode : "unknown person" }}
           </p>
 
           <div class="mt-2">
@@ -38,13 +38,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
 
-import { Survey } from '@/interfaces/survey'
-import { PatientRecord } from '@/interfaces/patientrecord'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { Survey } from "@/interfaces/survey";
+import { PatientRecord } from "@/interfaces/patientrecord";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 export default defineComponent({
   props: {
@@ -55,20 +55,20 @@ export default defineComponent({
   },
 
   setup(props) {
-    const { fetchPatientRecordSurveys } = fetchPatientRecords()
+    const { fetchPatientRecordSurveys } = fetchPatientRecords();
 
     // Data refs
-    const surveys = ref<Survey[]>()
+    const surveys = ref<Survey[]>();
 
     // Data fetching
     onMounted(async () => {
-      surveys.value = await fetchPatientRecordSurveys(props.record)
-    })
+      surveys.value = await fetchPatientRecordSurveys(props.record);
+    });
 
     return {
       surveys,
       formatDate,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/patientrecords/_pid/treatments.vue
+++ b/pages/patientrecords/_pid/treatments.vue
@@ -60,7 +60,7 @@
                         ? `(${treatment.dischargeReasonDesc})`
                         : treatment.dischargeReasonCode
                         ? `(${treatment.dischargeReasonCode})`
-                        : ''
+                        : ""
                     }}
                   </TextP>
                   <TextP v-else class="inline">
@@ -79,27 +79,27 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import { Treatment } from '@/interfaces/treatment'
-import { PatientRecord } from '@/interfaces/patientrecord'
-import fetchPatientRecords from '~/helpers/fetch/fetchPatientRecords'
+import { Treatment } from "@/interfaces/treatment";
+import { PatientRecord } from "@/interfaces/patientrecord";
+import fetchPatientRecords from "~/helpers/fetch/fetchPatientRecords";
 
 interface TreatmentEvent {
-  id: string
+  id: string;
 
-  time: string
-  isDischarge: boolean
+  time: string;
+  isDischarge: boolean;
 
-  admitReasonCode: string
-  admitReasonCodeStd: string
-  admitReasonDesc: string
+  admitReasonCode: string;
+  admitReasonCodeStd: string;
+  admitReasonDesc: string;
 
-  dischargeReasonCode: string
-  dischargeReasonCodeStd: string
-  dischargeReasonDesc: string
+  dischargeReasonCode: string;
+  dischargeReasonCodeStd: string;
+  dischargeReasonDesc: string;
 
-  healthCareFacilityCode: string
+  healthCareFacilityCode: string;
 }
 
 export default defineComponent({
@@ -111,19 +111,19 @@ export default defineComponent({
   },
 
   setup(props) {
-    const { fetchPatientRecordTreatments } = fetchPatientRecords()
+    const { fetchPatientRecordTreatments } = fetchPatientRecords();
 
     // Data refs
-    const treatments = ref<Treatment[]>()
+    const treatments = ref<Treatment[]>();
 
     // Data fetching
     onMounted(async () => {
-      treatments.value = await fetchPatientRecordTreatments(props.record)
-    })
+      treatments.value = await fetchPatientRecordTreatments(props.record);
+    });
 
     // Sorted and paired treatment events
     const treatmentEvents = computed(() => {
-      const events: TreatmentEvent[] = []
+      const events: TreatmentEvent[] = [];
       for (const treatment of treatments.value || []) {
         if (treatment.toTime) {
           const event = {
@@ -137,8 +137,8 @@ export default defineComponent({
             dischargeReasonCodeStd: treatment.dischargeReasonCodeStd,
             dischargeReasonDesc: treatment.dischargeReasonDesc,
             healthCareFacilityCode: treatment.healthCareFacilityCode,
-          }
-          events.push(event)
+          };
+          events.push(event);
         }
         const event = {
           id: treatment.id,
@@ -151,8 +151,8 @@ export default defineComponent({
           dischargeReasonCodeStd: treatment.dischargeReasonCodeStd,
           dischargeReasonDesc: treatment.dischargeReasonDesc,
           healthCareFacilityCode: treatment.healthCareFacilityCode,
-        }
-        events.push(event)
+        };
+        events.push(event);
       }
       events.sort(function (a, b) {
         // Turn your strings into dates, and then subtract them
@@ -161,21 +161,21 @@ export default defineComponent({
           // If they're part of the same treatment
           if (a.admitReasonDesc === b.admitReasonDesc) {
             // Admit before discharge
-            return (b.isDischarge ? 1 : 0) - (a.isDischarge ? 1 : 0)
+            return (b.isDischarge ? 1 : 0) - (a.isDischarge ? 1 : 0);
           } else {
             // Discharge before admit
-            return (a.isDischarge ? 1 : 0) - (b.isDischarge ? 1 : 0)
+            return (a.isDischarge ? 1 : 0) - (b.isDischarge ? 1 : 0);
           }
         }
-        return new Date(b.time).getTime() - new Date(a.time).getTime()
-      })
-      return events
-    })
+        return new Date(b.time).getTime() - new Date(a.time).getTime();
+      });
+      return events;
+    });
 
     return {
       treatments,
       treatmentEvents,
-    }
+    };
   },
-})
+});
 </script>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -29,7 +29,7 @@
             </h1>
             <p class="font-medium text-gray-500">
               {{ user.email }}
-              {{ user.email_verified ? '(Verified)' : '(Unverified)' }}
+              {{ user.email_verified ? "(Verified)" : "(Unverified)" }}
             </p>
           </div>
           <div v-else>
@@ -44,7 +44,7 @@
             :href="$config.manageAccountUrl"
             target="blank"
             type="button"
-            class="focus:outline-none rounded-md border border-gray-300 bg-white px-3 py-2 text-center font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            class="rounded-md border border-gray-300 bg-white px-3 py-2 text-center font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             >Manage Account</a
           >
           <GenericButton @click="logout"> Sign out </GenericButton>
@@ -66,42 +66,42 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 
-import useAuth from '~/helpers/useAuth'
-import usePermissions from '~/helpers/usePermissions'
+import useAuth from "~/helpers/useAuth";
+import usePermissions from "~/helpers/usePermissions";
 
 export default defineComponent({
   setup() {
-    const { getUser, signOut, signedIn } = useAuth()
-    const { getPermissions } = usePermissions()
+    const { getUser, signOut, signedIn } = useAuth();
+    const { getPermissions } = usePermissions();
 
     // User info
 
-    const user = ref()
+    const user = ref();
 
     onMounted(async () => {
-      user.value = await getUser()
-    })
+      user.value = await getUser();
+    });
 
     // Permissions
 
-    const perms = computed(() => getPermissions())
+    const perms = computed(() => getPermissions());
 
     function classesForPermissions(permission: string): string[] {
-      if (permission.includes('read')) {
-        return ['bg-green-100', 'text-green-800']
-      } else if (permission.includes('write')) {
-        return ['bg-red-100', 'text-red-800']
+      if (permission.includes("read")) {
+        return ["bg-green-100", "text-green-800"];
+      } else if (permission.includes("write")) {
+        return ["bg-red-100", "text-red-800"];
       } else {
-        return ['bg-indigo-100', 'text-indigo-800']
+        return ["bg-indigo-100", "text-indigo-800"];
       }
     }
 
     // Functions
 
     async function logout() {
-      await signOut()
+      await signOut();
     }
 
     return {
@@ -110,12 +110,12 @@ export default defineComponent({
       signedIn,
       logout,
       classesForPermissions,
-    }
+    };
   },
   head: {
-    title: 'Profile',
+    title: "Profile",
   },
-})
+});
 </script>
 
 <style></style>

--- a/pages/system.vue
+++ b/pages/system.vue
@@ -67,35 +67,35 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useContext } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useContext } from "@nuxtjs/composition-api";
 
-import fetchSystem from '~/helpers/fetch/fetchSystem'
+import fetchSystem from "~/helpers/fetch/fetchSystem";
 
 interface serverSystemInfo {
-  githubRef: string
-  githubSha: string
-  deploymentEnv: string
+  githubRef: string;
+  githubSha: string;
+  deploymentEnv: string;
 }
 
 export default defineComponent({
   setup() {
-    const { $config, $toast } = useContext()
-    const { fetchServerInfo } = fetchSystem()
+    const { $config, $toast } = useContext();
+    const { fetchServerInfo } = fetchSystem();
 
     // Data refs
 
-    const serverInfo = ref<serverSystemInfo>()
+    const serverInfo = ref<serverSystemInfo>();
     const clientInfo = ref({
       deploymentEnv: $config.deploymentEnv,
       githubRef: process.env.githubRef,
       githubSha: process.env.githubSha,
-    })
+    });
 
     // Data fetching
 
     onMounted(async () => {
-      serverInfo.value = await fetchServerInfo()
-    })
+      serverInfo.value = await fetchServerInfo();
+    });
 
     // Config reports
 
@@ -107,29 +107,29 @@ export default defineComponent({
         },
         null,
         4
-      )
-    })
+      );
+    });
 
     function copyConfigReport() {
       navigator.clipboard.writeText(configReportJSON.value).then(() => {
         $toast.show({
-          type: 'success',
-          title: 'Success',
-          message: 'Configuration Report copied to clipboard',
+          type: "success",
+          title: "Success",
+          message: "Configuration Report copied to clipboard",
           timeout: 5,
-          classTimeout: 'bg-green-600',
-        })
-      })
+          classTimeout: "bg-green-600",
+        });
+      });
     }
 
     return {
       serverInfo,
       clientInfo,
       copyConfigReport,
-    }
+    };
   },
   head: {
-    title: 'System Configuration',
+    title: "System Configuration",
   },
-})
+});
 </script>

--- a/pages/workitems/_id.vue
+++ b/pages/workitems/_id.vue
@@ -23,7 +23,7 @@
 
     <GenericModalSlot v-if="hasPermission('ukrdc:workitems:write')" ref="closeModal">
       <div class="text-left">
-        <div class="mb-4">{{ closeMessageOverride ? closeMessageOverride : 'Close the Work Item' }}</div>
+        <div class="mb-4">{{ closeMessageOverride ? closeMessageOverride : "Close the Work Item" }}</div>
 
         <div>
           <FormLabel>
@@ -238,79 +238,79 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref, useContext, useMeta, useRoute } from '@nuxtjs/composition-api'
+import { computed, defineComponent, onMounted, ref, useContext, useMeta, useRoute } from "@nuxtjs/composition-api";
 
-import { formatDate } from '@/helpers/utils/dateUtils'
-import { formatGender } from '@/helpers/utils/codeUtils'
-import { isEmptyObject } from '@/helpers/utils/objectUtils'
-import { delay } from '@/helpers/utils/timeUtils'
-import { workItemIsMergable } from '@/helpers/utils/workItemUtils'
+import { formatDate } from "@/helpers/utils/dateUtils";
+import { formatGender } from "@/helpers/utils/codeUtils";
+import { isEmptyObject } from "@/helpers/utils/objectUtils";
+import { delay } from "@/helpers/utils/timeUtils";
+import { workItemIsMergable } from "@/helpers/utils/workItemUtils";
 
-import { WorkItem, WorkItemExtended } from '@/interfaces/workitem'
-import { modalInterface } from '@/interfaces/modal'
+import { WorkItem, WorkItemExtended } from "@/interfaces/workitem";
+import { modalInterface } from "@/interfaces/modal";
 
-import usePermissions from '~/helpers/usePermissions'
-import fetchWorkItems from '~/helpers/fetch/fetchWorkItems'
+import usePermissions from "~/helpers/usePermissions";
+import fetchWorkItems from "~/helpers/fetch/fetchWorkItems";
 
 interface AvailableActions {
-  close: boolean
-  comment: boolean
-  merge: boolean
-  unlink: boolean
+  close: boolean;
+  comment: boolean;
+  merge: boolean;
+  unlink: boolean;
 }
 
 export default defineComponent({
   setup() {
     // Dependencies
-    const route = useRoute()
-    const { $toast } = useContext()
-    const { hasPermission } = usePermissions()
-    const { fetchWorkItem, closeWorkItem, putWorkItemComment, fetchWorkItemCollection } = fetchWorkItems()
+    const route = useRoute();
+    const { $toast } = useContext();
+    const { hasPermission } = usePermissions();
+    const { fetchWorkItem, closeWorkItem, putWorkItemComment, fetchWorkItemCollection } = fetchWorkItems();
 
     // Head
-    const { title } = useMeta()
-    title.value = `Work Item ${route.value.params.id}`
+    const { title } = useMeta();
+    title.value = `Work Item ${route.value.params.id}`;
 
     // Work item record data
-    const record = ref<WorkItemExtended>()
-    const customComment = ref('')
+    const record = ref<WorkItemExtended>();
+    const customComment = ref("");
 
     // Related persons data
-    const workItemCollection = ref([] as WorkItem[])
+    const workItemCollection = ref([] as WorkItem[]);
 
     // Related record paginator data
-    const relatedRecordsIndex = ref(0)
-    const relatedPersonsIndex = ref(0)
+    const relatedRecordsIndex = ref(0);
+    const relatedPersonsIndex = ref(0);
 
     // Data fetching
 
     async function getWorkItem() {
-      record.value = await fetchWorkItem(route.value.params.id)
-      workItemCollection.value = await fetchWorkItemCollection(record.value)
+      record.value = await fetchWorkItem(route.value.params.id);
+      workItemCollection.value = await fetchWorkItemCollection(record.value);
 
       // Apply existing comment
-      customComment.value = record.value?.updateDescription || ''
+      customComment.value = record.value?.updateDescription || "";
 
       // Check if the workitem has already been merged and is ready to be closed
-      checkMerged()
+      checkMerged();
     }
 
     onMounted(() => {
-      getWorkItem()
-    })
+      getWorkItem();
+    });
 
     // Trigger dynamic modals
 
     function checkMerged() {
       if (
         record.value?.status === 1 &&
-        record.value?.destination.masterRecord?.nationalidType === 'UKRDC' &&
+        record.value?.destination.masterRecord?.nationalidType === "UKRDC" &&
         record.value?.incoming.masterRecords.length <= 0 &&
-        route.value.query.justMerged === 'true'
+        route.value.query.justMerged === "true"
       ) {
         closeMessageOverride.value =
-          'It looks like the incoming Master Record for this Work Item has been merged. Close the Work Item?'
-        closeModal.value?.show()
+          "It looks like the incoming Master Record for this Work Item has been merged. Close the Work Item?";
+        closeModal.value?.show();
       }
     }
 
@@ -318,19 +318,19 @@ export default defineComponent({
 
     const statusString = computed(() => {
       if (record.value?.status === 1) {
-        return ''
+        return "";
       } else if (record.value?.status === 2) {
-        return '(WIP)'
+        return "(WIP)";
       } else if (record.value?.status === 3) {
-        return '(Closed)'
+        return "(Closed)";
       } else {
-        return '(Unknown status)'
+        return "(Unknown status)";
       }
-    })
+    });
 
-    const showIncomingAttributes = ref(false)
+    const showIncomingAttributes = ref(false);
 
-    const showDestinationPersons = ref(false)
+    const showDestinationPersons = ref(false);
 
     const availableActions = computed<AvailableActions>(() => {
       return {
@@ -342,76 +342,76 @@ export default defineComponent({
         merge: record.value ? workItemIsMergable(record.value) : false,
         // Currently Unlink never makes sense, so ignore for now. Maybe remove entirely?
         unlink: false,
-      } as AvailableActions
-    })
+      } as AvailableActions;
+    });
 
-    const closeMessageOverride = ref<String>()
+    const closeMessageOverride = ref<String>();
 
     // Template refs
-    const addCommentModal = ref<modalInterface>()
-    const closeModal = ref<modalInterface>()
+    const addCommentModal = ref<modalInterface>();
+    const closeModal = ref<modalInterface>();
 
     // Workitem actions
     function updateWorkItemComment() {
       putWorkItemComment(route.value.params.id, customComment.value)
         .then(() => {
           $toast.show({
-            type: 'success',
-            title: 'Success',
-            message: 'Comment added',
-            classTimeout: 'bg-green-600',
-          })
+            type: "success",
+            title: "Success",
+            message: "Comment added",
+            classTimeout: "bg-green-600",
+          });
         })
         .catch((error) => {
           $toast.show({
-            type: 'danger',
-            title: 'Error',
+            type: "danger",
+            title: "Error",
             message: error.response.data.detail,
             timeout: 10,
-            classTimeout: 'bg-red-600',
-          })
-          throw error
+            classTimeout: "bg-red-600",
+          });
+          throw error;
         })
         .finally(() => {
           // Delay fetch to allow JTRACE time to process
           delay(1000).then(() => {
-            getWorkItem()
-          })
-        })
+            getWorkItem();
+          });
+        });
 
-      const el = addCommentModal.value as modalInterface
-      el.toggle()
+      const el = addCommentModal.value as modalInterface;
+      el.toggle();
     }
 
     function handleCloseWorkItem() {
       closeWorkItem(route.value.params.id, customComment.value)
         .then(() => {
           $toast.show({
-            type: 'success',
-            title: 'Success',
-            message: 'Work Item closed',
-            classTimeout: 'bg-green-600',
-          })
+            type: "success",
+            title: "Success",
+            message: "Work Item closed",
+            classTimeout: "bg-green-600",
+          });
         })
         .catch((error) => {
           $toast.show({
-            type: 'danger',
-            title: 'Error',
+            type: "danger",
+            title: "Error",
             message: error.response.data.detail,
             timeout: 10,
-            classTimeout: 'bg-red-600',
-          })
-          throw error
+            classTimeout: "bg-red-600",
+          });
+          throw error;
         })
         .finally(() => {
           // Delay fetch to allow JTRACE time to process
           delay(1000).then(() => {
-            getWorkItem()
-          })
-        })
+            getWorkItem();
+          });
+        });
 
-      const el = closeModal.value as modalInterface
-      el.toggle()
+      const el = closeModal.value as modalInterface;
+      el.toggle();
     }
 
     return {
@@ -433,10 +433,10 @@ export default defineComponent({
       updateWorkItemComment,
       handleCloseWorkItem,
       hasPermission,
-    }
+    };
   },
   head: {
-    title: 'Work Item',
+    title: "Work Item",
   },
-})
+});
 </script>

--- a/pages/workitems/index.vue
+++ b/pages/workitems/index.vue
@@ -58,63 +58,63 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from '@nuxtjs/composition-api'
+import { defineComponent, onMounted, ref, watch } from "@nuxtjs/composition-api";
 
-import { WorkItem } from '@/interfaces/workitem'
-import usePagination from '~/helpers/query/usePagination'
+import { WorkItem } from "@/interfaces/workitem";
+import usePagination from "~/helpers/query/usePagination";
 
-import useQuery from '~/helpers/query/useQuery'
-import useFacilities from '~/helpers/useFacilities'
-import useSortBy from '~/helpers/query/useSortBy'
+import useQuery from "~/helpers/query/useQuery";
+import useFacilities from "~/helpers/useFacilities";
+import useSortBy from "~/helpers/query/useSortBy";
 
-import fetchWorkItems from '~/helpers/fetch/fetchWorkItems'
-import useDateRange from '~/helpers/query/useDateRange'
+import fetchWorkItems from "~/helpers/fetch/fetchWorkItems";
+import useDateRange from "~/helpers/query/useDateRange";
 
 export default defineComponent({
   setup() {
-    const { page, total, size } = usePagination()
-    const { makeDateRange } = useDateRange()
-    const { arrayQuery } = useQuery()
-    const { facilities, facilityIds, facilityLabels, selectedFacility } = useFacilities()
-    const { orderAscending, orderBy, toggleOrder } = useSortBy()
-    const { fetchWorkItemsPage } = fetchWorkItems()
+    const { page, total, size } = usePagination();
+    const { makeDateRange } = useDateRange();
+    const { arrayQuery } = useQuery();
+    const { facilities, facilityIds, facilityLabels, selectedFacility } = useFacilities();
+    const { orderAscending, orderBy, toggleOrder } = useSortBy();
+    const { fetchWorkItemsPage } = fetchWorkItems();
 
     // Data refs
 
-    const workitems = ref<WorkItem[]>()
-    const statuses = arrayQuery('status', ['1'], true, true)
+    const workitems = ref<WorkItem[]>();
+    const statuses = arrayQuery("status", ["1"], true, true);
 
-    const fetchInProgress = ref(false)
+    const fetchInProgress = ref(false);
 
     // Set initial date dateRange
-    const dateRange = makeDateRange(null, null, true, true)
+    const dateRange = makeDateRange(null, null, true, true);
 
     // Data fetching
 
     async function getWorkitems() {
-      fetchInProgress.value = true
+      fetchInProgress.value = true;
 
       const itemsPage = await fetchWorkItemsPage(
         page.value || 1,
         size.value,
-        orderBy.value || 'desc',
+        orderBy.value || "desc",
         statuses.value,
         selectedFacility.value,
         dateRange.value.start,
         dateRange.value.end
-      )
+      );
 
-      workitems.value = itemsPage.items
-      page.value = itemsPage.page
-      total.value = itemsPage.total
-      size.value = itemsPage.size
+      workitems.value = itemsPage.items;
+      page.value = itemsPage.page;
+      total.value = itemsPage.total;
+      size.value = itemsPage.size;
 
-      fetchInProgress.value = false
+      fetchInProgress.value = false;
     }
 
     onMounted(() => {
-      getWorkitems()
-    })
+      getWorkitems();
+    });
 
     watch(
       [
@@ -125,9 +125,9 @@ export default defineComponent({
         () => JSON.stringify(statuses.value), // Stringify to watch for actual value changes
       ],
       () => {
-        getWorkitems()
+        getWorkitems();
       }
-    )
+    );
 
     return {
       fetchInProgress,
@@ -144,12 +144,12 @@ export default defineComponent({
       orderAscending,
       orderBy,
       toggleOrder,
-    }
+    };
   },
   head: {
-    title: 'Work Items',
+    title: "Work Items",
   },
-})
+});
 </script>
 
 <style></style>

--- a/plugins/axios-error-handlers.ts
+++ b/plugins/axios-error-handlers.ts
@@ -1,21 +1,21 @@
 /*
 Automatically redirect to an error page on API fetch errors.
 */
-import { Context } from '@nuxt/types'
+import { Context } from "@nuxt/types";
 
 interface PydanticError {
-  loc: string[]
-  msg: string
-  type: string
+  loc: string[];
+  msg: string;
+  type: string;
 }
 
 function decodePydanticErrors(errors: PydanticError[]) {
-  let errorMessage = 'Parameter Error\n'
+  let errorMessage = "Parameter Error\n";
   for (const error of errors) {
-    const msg = `${error.loc.join('/')}: ${error.msg}`
-    errorMessage += `${msg}\n`
+    const msg = `${error.loc.join("/")}: ${error.msg}`;
+    errorMessage += `${msg}\n`;
   }
-  return errorMessage
+  return errorMessage;
 }
 
 export default function ({ error, app, $api, $sentry }: Context) {
@@ -26,48 +26,48 @@ export default function ({ error, app, $api, $sentry }: Context) {
     // handle the refresh.
     if (thisError.response?.status === 401) {
       // Return early
-      throw thisError
+      throw thisError;
     }
 
     // For API 404 errors a resource is usually missing or unavailable, and is
     // generally handled by the component that triggered the request. Don't show toasts or log.
     if (thisError.response?.status === 404) {
       // Return early
-      throw thisError
+      throw thisError;
     }
 
     // For internal API server errors, redirect to 500 without propagating Sentry or toast
     // We're assuming here that the API server will log the related error, and so logging
     // here just leads to duplicate messages.
     if (thisError.response?.status === 500) {
-      error({ statusCode: 500, message: 'Internal server error' })
+      error({ statusCode: 500, message: "Internal server error" });
       // Return early
-      throw thisError
+      throw thisError;
     }
 
     // Build message and redirect to 422 without propagating Sentry or toast
     if (thisError.response?.status === 422) {
-      const msg = decodePydanticErrors(thisError.response.data.detail)
-      error({ statusCode: 422, message: msg })
+      const msg = decodePydanticErrors(thisError.response.data.detail);
+      error({ statusCode: 422, message: msg });
       // Return early
-      throw thisError
+      throw thisError;
     }
 
     // Compute what message to show in the toast
     if (process.client) {
-      const msgToShow = thisError.response ? thisError.response.data.detail : thisError.message
+      const msgToShow = thisError.response ? thisError.response.data.detail : thisError.message;
       // If we have no message to show, don't create a toast
       if (msgToShow) {
         app.$toast.show({
-          type: 'danger',
-          title: 'Error Fetching Data',
+          type: "danger",
+          title: "Error Fetching Data",
           message: msgToShow,
           timeout: 5,
-        })
+        });
       }
     }
 
     // Log the error to Sentry
-    $sentry.captureException(thisError)
-  })
+    $sentry.captureException(thisError);
+  });
 }

--- a/plugins/axios-ukrdc-api.client.ts
+++ b/plugins/axios-ukrdc-api.client.ts
@@ -1,6 +1,6 @@
-import { Context } from '@nuxt/types'
-import { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios'
-import { isAbsolute, urljoin } from '~/helpers/utils/pathUtils'
+import { Context } from "@nuxt/types";
+import { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosStatic } from "axios";
+import { isAbsolute, urljoin } from "~/helpers/utils/pathUtils";
 
 /* 
 TEMPORARY REDEFINITION OF NuxtAxiosInstance TYPE
@@ -14,41 +14,41 @@ import { NuxtAxiosInstance } from '@nuxtjs/axios'
 */
 
 interface NuxtAxiosInstance extends AxiosStatic {
-  $request<T = any>(config: AxiosRequestConfig): Promise<T>
-  $get<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
-  $delete<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
-  $head<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
-  $options<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
-  $post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>
-  $put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>
-  $patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>
+  $request<T = any>(config: AxiosRequestConfig): Promise<T>;
+  $get<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  $delete<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  $head<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  $options<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  $post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>;
+  $put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>;
+  $patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>;
 
-  setBaseURL(baseURL: string): void
-  setHeader(name: string, value?: string | false, scopes?: string | string[]): void
-  setToken(token: string | false, type?: string, scopes?: string | string[]): void
+  setBaseURL(baseURL: string): void;
+  setHeader(name: string, value?: string | false, scopes?: string | string[]): void;
+  setToken(token: string | false, type?: string, scopes?: string | string[]): void;
 
-  onRequest(callback: (config: AxiosRequestConfig) => void | AxiosRequestConfig | Promise<AxiosRequestConfig>): void
+  onRequest(callback: (config: AxiosRequestConfig) => void | AxiosRequestConfig | Promise<AxiosRequestConfig>): void;
   onResponse<T = any>(
     callback: (response: AxiosResponse<T>) => void | AxiosResponse<T> | Promise<AxiosResponse<T>>
-  ): void
-  onError(callback: (error: AxiosError) => any): void
-  onRequestError(callback: (error: AxiosError) => any): void
-  onResponseError(callback: (error: AxiosError) => any): void
+  ): void;
+  onError(callback: (error: AxiosError) => any): void;
+  onRequestError(callback: (error: AxiosError) => any): void;
+  onResponseError(callback: (error: AxiosError) => any): void;
 
-  create(options?: AxiosRequestConfig): NuxtAxiosInstance
+  create(options?: AxiosRequestConfig): NuxtAxiosInstance;
 }
 
 // Add our injected $api into the Vue instance and context interfaces
 
-declare module 'vue/types/vue' {
+declare module "vue/types/vue" {
   interface Vue {
-    $api: NuxtAxiosInstance
+    $api: NuxtAxiosInstance;
   }
 }
 
-declare module '@nuxt/types' {
+declare module "@nuxt/types" {
   interface Context {
-    $api: NuxtAxiosInstance
+    $api: NuxtAxiosInstance;
   }
 }
 
@@ -59,10 +59,10 @@ export default function ({ $axios, $okta, $config }: Context, inject: Function) 
   const api = $axios.create({
     headers: {
       common: {
-        Accept: 'application/json',
+        Accept: "application/json",
       },
     },
-  })
+  });
 
   // If we're overriding the API host (e.g. for running the API locally
   // on a different port or server) then we need to set the baseURL to
@@ -70,7 +70,7 @@ export default function ({ $axios, $okta, $config }: Context, inject: Function) 
   // NB: This is only really relevant for local development, in production
   // the user-facing app and API run on the same host and port, so we set
   // the baseURL to / (i.e. the current host the user is connected to).
-  api.setBaseURL($config.api.host || '/')
+  api.setBaseURL($config.api.host || "/");
 
   // Request interceptor to handle API base paths and authentication
   api.interceptors.request.use((config) => {
@@ -80,19 +80,19 @@ export default function ({ $axios, $okta, $config }: Context, inject: Function) 
       // so we don't need to add it again.
       // Likewise, we assume any absolute URLs are already correct.
       if (!isAbsolute(config.url) && !config.url.startsWith($config.api.base)) {
-        config.url = urljoin($config.api.base, config.url)
+        config.url = urljoin($config.api.base, config.url);
       }
     }
 
     // Add the authorization header to each request
-    const token = $okta.getAccessToken()
+    const token = $okta.getAccessToken();
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`
+      config.headers.Authorization = `Bearer ${token}`;
     }
 
-    return config
-  })
+    return config;
+  });
 
   // Inject to context as $api
-  inject('api', api)
+  inject("api", api);
 }

--- a/plugins/okta-auth.client.ts
+++ b/plugins/okta-auth.client.ts
@@ -3,22 +3,22 @@ Injects an $okta object into the Vue instance and context,
 allowing components to interact with a shared OktaAuth instance.
 */
 
-import { Plugin } from '@nuxt/types'
+import { Plugin } from "@nuxt/types";
 
-import { OktaAuth } from '@okta/okta-auth-js'
-import { urljoin } from '~/helpers/utils/pathUtils'
+import { OktaAuth } from "@okta/okta-auth-js";
+import { urljoin } from "~/helpers/utils/pathUtils";
 
 // Add our injected $okta into the Vue instance and context interfaces
 
-declare module 'vue/types/vue' {
+declare module "vue/types/vue" {
   interface Vue {
-    $okta: OktaAuth
+    $okta: OktaAuth;
   }
 }
 
-declare module '@nuxt/types' {
+declare module "@nuxt/types" {
   interface Context {
-    $okta: OktaAuth
+    $okta: OktaAuth;
   }
 }
 
@@ -26,26 +26,26 @@ declare module '@nuxt/types' {
 
 const oktaPlugin: Plugin = (_ctx, inject) => {
   // Common variables
-  const router = _ctx.app.router
-  const basePath = router?.options.base || '/'
+  const router = _ctx.app.router;
+  const basePath = router?.options.base || "/";
 
   // Fetch (runtime) config from context
-  const configOptions = _ctx.$config.okta
+  const configOptions = _ctx.$config.okta;
 
   // Assert router base is prepended to callback URLs
   if (configOptions.postLogoutRedirectUri) {
-    configOptions.postLogoutRedirectUri = urljoin(basePath, configOptions.postLogoutRedirectUri)
+    configOptions.postLogoutRedirectUri = urljoin(basePath, configOptions.postLogoutRedirectUri);
   }
   if (configOptions.redirectUri) {
-    configOptions.redirectUri = urljoin(basePath, configOptions.redirectUri)
+    configOptions.redirectUri = urljoin(basePath, configOptions.redirectUri);
   }
 
   // Create OktaAuth instance
-  const oktaAuth = new OktaAuth(configOptions)
+  const oktaAuth = new OktaAuth(configOptions);
 
   // Start the auth background service
-  console.debug('Starting OktaAuth service...')
-  oktaAuth.start()
+  console.debug("Starting OktaAuth service...");
+  oktaAuth.start();
 
   // Look for a router instance to handle URI restoration
   if (!oktaAuth.options.restoreOriginalUri) {
@@ -55,13 +55,13 @@ const oktaPlugin: Plugin = (_ctx, inject) => {
       if (router && originalUri) {
         // Our originalUri will always be a router path (i.e. route.value.fullPath, see useAuth.ts),
         // so we can pass it straight through to the router without any further modifications.
-        router.replace({ path: originalUri })
+        router.replace({ path: originalUri });
       }
-    }
+    };
   }
 
   // Inject oktaAuth into Vue
-  inject('okta', oktaAuth)
-}
+  inject("okta", oktaAuth);
+};
 
-export default oktaPlugin
+export default oktaPlugin;

--- a/plugins/sentry-usercontext.client.ts
+++ b/plugins/sentry-usercontext.client.ts
@@ -1,27 +1,27 @@
 /*
 Automatically set and clear the Sentry usercontext based on auth status.
 */
-import { Context } from '@nuxt/types'
-import { AuthState } from '@okta/okta-auth-js'
+import { Context } from "@nuxt/types";
+import { AuthState } from "@okta/okta-auth-js";
 
 export default function ({ $okta, $sentry }: Context) {
   // When auth state changes, update sentry user context
   function _handleAuthStateUpdate(newAuthState: AuthState | null) {
     if (newAuthState && newAuthState.isAuthenticated) {
-      const rawIdToken = $okta.getIdToken()
-      const idToken = rawIdToken ? $okta.token.decode(rawIdToken) : null
+      const rawIdToken = $okta.getIdToken();
+      const idToken = rawIdToken ? $okta.token.decode(rawIdToken) : null;
       $sentry.setUser({
         id: idToken?.payload.sub,
         email: idToken?.payload.email,
-      })
+      });
     } else {
-      $sentry.setUser(null)
+      $sentry.setUser(null);
     }
   }
 
   // Populate Sentry user
-  _handleAuthStateUpdate($okta.authStateManager.getAuthState())
+  _handleAuthStateUpdate($okta.authStateManager.getAuthState());
 
   // Subscribe to auth state changes
-  $okta.authStateManager.subscribe(_handleAuthStateUpdate)
+  $okta.authStateManager.subscribe(_handleAuthStateUpdate);
 }

--- a/plugins/toast.client.ts
+++ b/plugins/toast.client.ts
@@ -3,75 +3,75 @@ Injects a $toast object into the Vue instance and context,
 allowing programatic toast creation.
 */
 
-import { Plugin } from '@nuxt/types'
-import Vue from 'vue'
-import { spawn } from '@/helpers/utils/domUtils'
-import Toast from '~/components/generic/Toast.vue'
+import { Plugin } from "@nuxt/types";
+import Vue from "vue";
+import { spawn } from "@/helpers/utils/domUtils";
+import Toast from "~/components/generic/Toast.vue";
 
 const containerClasses = [
-  'z-40',
-  'fixed',
-  'inset-0',
-  'flex',
-  'flex-col-reverse',
-  'items-end',
-  'justify-center',
-  'px-4',
-  'py-6',
-  'pointer-events-none',
-  'sm:p-6',
-  'sm:items-end',
-  'sm:justify-end',
-]
+  "z-40",
+  "fixed",
+  "inset-0",
+  "flex",
+  "flex-col-reverse",
+  "items-end",
+  "justify-center",
+  "px-4",
+  "py-6",
+  "pointer-events-none",
+  "sm:p-6",
+  "sm:items-end",
+  "sm:justify-end",
+];
 
 const toastProgrammatic = {
   show(props: object | string): Vue {
-    if (typeof props === 'string') props = { message: props }
-    return spawn('toasts', props, Toast, Vue)
+    if (typeof props === "string") props = { message: props };
+    return spawn("toasts", props, Toast, Vue);
   },
   success(message: string) {
-    return spawn('toasts', { type: 'success', message }, Toast, Vue)
+    return spawn("toasts", { type: "success", message }, Toast, Vue);
   },
   info(message: string) {
-    return spawn('toasts', { type: 'info', message }, Toast, Vue)
+    return spawn("toasts", { type: "info", message }, Toast, Vue);
   },
   danger(message: string) {
-    return spawn('toasts', { type: 'danger', message }, Toast, Vue)
+    return spawn("toasts", { type: "danger", message }, Toast, Vue);
   },
   warning(message: string) {
-    return spawn('toasts', { type: 'warning', message }, Toast, Vue)
+    return spawn("toasts", { type: "warning", message }, Toast, Vue);
   },
   denied(message: string) {
-    return spawn('toasts', { type: 'denied', message }, Toast, Vue)
+    return spawn("toasts", { type: "denied", message }, Toast, Vue);
   },
-}
+};
 
-declare module 'vue/types/vue' {
+declare module "vue/types/vue" {
   interface Vue {
-    $toast: typeof toastProgrammatic
+    $toast: typeof toastProgrammatic;
   }
 }
 
-declare module '@nuxt/types' {
+declare module "@nuxt/types" {
   // nuxtContext.app.$toast inside asyncData, fetch, plugins, middleware, nuxtServerInit
   interface NuxtAppOptions {
-    $toast: typeof toastProgrammatic
+    $toast: typeof toastProgrammatic;
   }
   // nuxtContext.$myInjectedFunction
   interface Context {
-    $toast: typeof toastProgrammatic
+    $toast: typeof toastProgrammatic;
   }
 }
 
 const toastPlugin: Plugin = (_ctx, inject) => {
   // Create a div to hold created toasts
-  const toasts = document.createElement('div')
-  containerClasses.forEach((c) => toasts.classList.add(c))
-  toasts.setAttribute('id', 'toasts')
-  document.body.appendChild(toasts)
+  const toasts = document.createElement("div");
+  containerClasses.forEach((c) => toasts.classList.add(c));
+  toasts.setAttribute("id", "toasts");
+  document.body.appendChild(toasts);
 
   // Inject toastProgrammatic into Vue
-  inject('toast', toastProgrammatic)
-}
+  inject("toast", toastProgrammatic);
+};
 
-export default toastPlugin
+export default toastPlugin;

--- a/plugins/v-calendar.client.ts
+++ b/plugins/v-calendar.client.ts
@@ -2,7 +2,7 @@
 Plugin to make Vcalendar component globally available
 */
 
-import Vue from 'vue'
-import Vcalendar from 'v-calendar'
+import Vue from "vue";
+import Vcalendar from "v-calendar";
 
-Vue.use(Vcalendar)
+Vue.use(Vcalendar);

--- a/plugins/v-tooltip.client.ts
+++ b/plugins/v-tooltip.client.ts
@@ -1,9 +1,9 @@
-import Vue from 'vue'
-import { VTooltip, VClosePopper, Dropdown, Tooltip, Menu } from 'v-tooltip'
+import Vue from "vue";
+import { VTooltip, VClosePopper, Dropdown, Tooltip, Menu } from "v-tooltip";
 
-Vue.directive('tooltip', VTooltip)
-Vue.directive('close-popper', VClosePopper)
+Vue.directive("tooltip", VTooltip);
+Vue.directive("close-popper", VClosePopper);
 
-Vue.component('VDropdown', Dropdown)
-Vue.component('VTooltip', Tooltip)
-Vue.component('VMenu', Menu)
+Vue.component("VDropdown", Dropdown);
+Vue.component("VTooltip", Tooltip);
+Vue.component("VMenu", Menu);

--- a/plugins/vue-clickaway.client.ts
+++ b/plugins/vue-clickaway.client.ts
@@ -25,50 +25,50 @@ SOFTWARE.
 */
 
 // eslint-disable-next-line import/named
-import Vue, { VNode } from 'vue'
-import { DirectiveBinding } from 'vue/types/options'
+import Vue, { VNode } from "vue";
+import { DirectiveBinding } from "vue/types/options";
 
-const clickEventType = document.ontouchstart !== null ? 'click' : 'touchstart'
+const clickEventType = document.ontouchstart !== null ? "click" : "touchstart";
 
 interface ClickAwayElement extends HTMLElement {
   // eslint-disable-next-line camelcase
-  __vue_click_away__?: (event: Event) => void
+  __vue_click_away__?: (event: Event) => void;
 }
 
 const onMounted = (el: ClickAwayElement, binding: DirectiveBinding, vnode: VNode) => {
   // Remove any existing clickaway callbacks
-  onUnmounted(el)
+  onUnmounted(el);
 
-  const vm = vnode.context
-  const callback = binding.value
+  const vm = vnode.context;
+  const callback = binding.value;
 
-  let nextTick = false
+  let nextTick = false;
   setTimeout(function () {
-    nextTick = true
-  }, 0)
+    nextTick = true;
+  }, 0);
 
   el.__vue_click_away__ = (event: Event) => {
-    if ((!el || !el.contains(event.target as Node)) && callback && nextTick && typeof callback === 'function') {
-      return callback.call(vm, event)
+    if ((!el || !el.contains(event.target as Node)) && callback && nextTick && typeof callback === "function") {
+      return callback.call(vm, event);
     }
-  }
+  };
 
-  document.addEventListener(clickEventType, el.__vue_click_away__, false)
-}
+  document.addEventListener(clickEventType, el.__vue_click_away__, false);
+};
 
 const onUnmounted = (el: ClickAwayElement) => {
   if (el.__vue_click_away__) {
-    document.removeEventListener(clickEventType, el.__vue_click_away__, false)
-    delete el.__vue_click_away__
+    document.removeEventListener(clickEventType, el.__vue_click_away__, false);
+    delete el.__vue_click_away__;
   }
-}
+};
 
 const onUpdated = (el: ClickAwayElement, binding: DirectiveBinding, vnode: VNode) => {
   if (binding.value === binding.oldValue) {
-    return
+    return;
   }
-  onMounted(el, binding, vnode)
-}
+  onMounted(el, binding, vnode);
+};
 
 const directive = {
   inserted: onMounted,
@@ -78,6 +78,6 @@ const directive = {
   // mounted: onMounted,
   // updated: onUpdated,
   // unmounted: onUnmounted,
-}
+};
 
-Vue.directive('click-away', directive)
+Vue.directive("click-away", directive);

--- a/plugins/vuex-persistedstate.client.ts
+++ b/plugins/vuex-persistedstate.client.ts
@@ -1,12 +1,12 @@
-import createPersistedState from 'vuex-persistedstate'
-import { Context } from '@nuxt/types'
+import createPersistedState from "vuex-persistedstate";
+import { Context } from "@nuxt/types";
 
 // We don't need to use cookies to store the state of the vuex store, since we render all pages client-side.
 // See https://github.com/robinvdvleuten/vuex-persistedstate#using-cookies-universal-client--server-side
 
 export default ({ store }: Context) => {
   createPersistedState({
-    key: 'vuex.persisted_state.prefs',
-    paths: ['prefs'],
-  })(store)
-}
+    key: "vuex.persisted_state.prefs",
+    paths: ["prefs"],
+  })(store);
+};

--- a/shims-plugins.d.ts
+++ b/shims-plugins.d.ts
@@ -1,2 +1,2 @@
-declare module 'v-calendar'
-declare module 'v-tooltip'
+declare module "v-calendar";
+declare module "v-tooltip";

--- a/shims-vue.d.ts
+++ b/shims-vue.d.ts
@@ -1,4 +1,4 @@
-declare module '*.vue' {
-  import Vue from 'vue'
-  export default Vue
+declare module "*.vue" {
+  import Vue from "vue";
+  export default Vue;
 }

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,21 +1,21 @@
-import { GetterTree, MutationTree } from 'vuex'
+import { GetterTree, MutationTree } from "vuex";
 
 interface UserPrefs {
-  searchShowUKRDC: boolean
+  searchShowUKRDC: boolean;
 }
 
 export const state = () => ({
   prefs: {
     searchShowUKRDC: false,
   } as UserPrefs,
-})
+});
 
-export type RootState = ReturnType<typeof state>
+export type RootState = ReturnType<typeof state>;
 
 export const getters: GetterTree<RootState, RootState> = {
   searchShowUKRDC: (state) => state.prefs.searchShowUKRDC,
-}
+};
 
 export const mutations: MutationTree<RootState> = {
   changeSearchShowUKRDC: (state, newValue: boolean) => (state.prefs.searchShowUKRDC = newValue),
-}
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,24 +9,24 @@ module.exports = {
   theme: {
     extend: {},
     fontSize: {
-      xs: '.75rem',
-      sm: '.8rem',
-      base: '1rem',
-      lg: '1.125rem',
-      xl: '1.25rem',
-      '2xl': '1.5rem',
-      '3xl': '1.875rem',
-      '4xl': '2.25rem',
-      '5xl': '3rem',
-      '6xl': '4rem',
+      xs: ".75rem",
+      sm: ".8rem",
+      base: "1rem",
+      lg: "1.125rem",
+      xl: "1.25rem",
+      "2xl": "1.5rem",
+      "3xl": "1.875rem",
+      "4xl": "2.25rem",
+      "5xl": "3rem",
+      "6xl": "4rem",
     },
   },
   variants: {
     variants: {
       extend: {
-        opacity: ['disabled'],
+        opacity: ["disabled"],
       },
     },
   },
-  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/line-clamp')],
-}
+  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,11 @@
 module.exports = {
-  purge: [],
-  content: ['node_modules/tv-*/dist/tv-*.umd.min.js'],
+  content: [
+    "./components/**/*.{js,vue,ts}",
+    "./layouts/**/*.vue",
+    "./pages/**/*.vue",
+    "./plugins/**/*.{js,ts}",
+    "./nuxt.config.{js,ts}",
+  ],
   theme: {
     extend: {},
     fontSize: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,12 +21,5 @@ module.exports = {
       "6xl": "4rem",
     },
   },
-  variants: {
-    variants: {
-      extend: {
-        opacity: ["disabled"],
-      },
-    },
-  },
   plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,17 +986,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@koa/router@^9.0.1":
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/@koa/router/-/router-9.4.0.tgz#734b64c0ae566eb5af752df71e4143edc4748e48"
-  integrity sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==
-  dependencies:
-    debug "^4.1.1"
-    http-errors "^1.7.3"
-    koa-compose "^4.1.0"
-    methods "^1.1.2"
-    path-to-regexp "^6.1.0"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1475,24 +1464,6 @@
     consola "^2.15.3"
     lodash.mergewith "^4.6.2"
 
-"@nuxtjs/tailwindcss@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/tailwindcss/-/tailwindcss-4.2.1.tgz#bd0dc5e0d7f02aebe15bc2384c003687e6e5d508"
-  integrity sha512-Sku7VETunn5YmvzkXFDuRdP1gUGau02eh5HtcAsI9//1hpSuEN49n3XhatBrPOXQ57WhUlnjXf0/LjT9KQH0+A==
-  dependencies:
-    "@nuxt/postcss8" "^1.1.3"
-    autoprefixer "^10.2.5"
-    chalk "^4.1.1"
-    clear-module "^4.1.1"
-    consola "^2.15.3"
-    defu "^5.0.0"
-    postcss "^8.3.5"
-    postcss-custom-properties "^11.0.0"
-    postcss-nesting "^8.0.1"
-    tailwind-config-viewer "^1.6.2"
-    tailwindcss "^2.2.2"
-    ufo "^0.7.5"
-
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -1686,17 +1657,17 @@
   dependencies:
     "@sentry/cli" "^1.72.0"
 
-"@tailwindcss/forms@^0.3.2":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.3.4.tgz#e4939dc16450eccf4fd2029770096f38cbb556d4"
-  integrity sha512-vlAoBifNJUkagB+PAdW4aHMe4pKmSLroH398UPgIogBFc91D2VlHUxe4pjxQhiJl0Nfw53sHSJSQBSTQBZP3vA==
+"@tailwindcss/forms@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.4.0.tgz#a46715e347a32d216a3973eb67473bd29ae3798e"
+  integrity sha512-DeaQBx6EgEeuZPQACvC+mKneJsD8am1uiJugjgQK1+/Vt+Ai0GpFBC2T2fqnUad71WgOxyrZPE6BG1VaI6YqfQ==
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
-"@tailwindcss/line-clamp@^0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.2.2.tgz#05843c004bf069353a0c43f9df8cc3a6016252b8"
-  integrity sha512-NgA4Ds+/eCiO+6O3SooRsfJ8m7M2+QvNvHwOjBQq7FIYoWwAV4I4Wu4fjHeuO9Yi6p47ceHUKEGGEBh0ozQodg==
+"@tailwindcss/line-clamp@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz#4d8441b509b87ece84e94f28a4aa9998413ab849"
+  integrity sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==
 
 "@types/anymatch@*":
   version "3.0.0"
@@ -2460,7 +2431,7 @@ Base64@1.1.0:
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.1.0.tgz#810ef21afa8357df92ad7b5389188c446b9cb956"
   integrity sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q==
 
-accepts@^1.3.5, accepts@~1.3.5:
+accepts@~1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -2726,13 +2697,6 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
-
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
@@ -2743,7 +2707,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^10.2.5:
+autoprefixer@^10.2.5, autoprefixer@^10.4.2:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.2.tgz#25e1df09a31a9fba5c40b578936b90d35c9d4d3b"
   integrity sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==
@@ -3063,11 +3027,6 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-bytes@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
-  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
-
 cacache@^12.0.2:
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c"
@@ -3128,14 +3087,6 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cache-content-type@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cache-content-type/-/cache-content-type-1.0.1.tgz#035cde2b08ee2129f4a8315ea8f00a00dba1453c"
-  integrity sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==
-  dependencies:
-    mime-types "^2.1.18"
-    ylru "^1.2.0"
-
 cache-loader@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-4.1.0.tgz#9948cae353aec0a1fcb1eafda2300816ec85387e"
@@ -3175,7 +3126,7 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
-callsites@^3.0.0, callsites@^3.1.0:
+callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -3293,7 +3244,7 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1, chokidar@^3.5.2:
+chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1, chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -3365,14 +3316,6 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-clear-module@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/clear-module/-/clear-module-4.1.2.tgz#5a58a5c9f8dccf363545ad7284cad3c887352a80"
-  integrity sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==
-  dependencies:
-    parent-module "^2.0.0"
-    resolve-from "^5.0.0"
-
 cli-boxes@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
@@ -3390,24 +3333,10 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
-
 clone@2.x:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 coa@^2.0.2:
   version "2.0.2"
@@ -3455,7 +3384,7 @@ color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.6.0, color-string@^1.9.0:
+color-string@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.0.tgz#63b6ebd1bec11999d1df3a79a7569451ac2be8aa"
   integrity sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==
@@ -3470,14 +3399,6 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.3"
     color-string "^1.6.0"
-
-color@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-4.2.0.tgz#0c782459a3e98838ea01e4bc0fb43310ca35af78"
-  integrity sha512-hHTcrbvEnGjC7WBMk6ibQWFVDgEFTVmjrz2Q5HlU6ltwxv0JJN2Z8I7uRbWeQLF04dikxs8zgyZkazRJvSMtyQ==
-  dependencies:
-    color-convert "^2.0.1"
-    color-string "^1.9.0"
 
 colorette@^1.2.2:
   version "1.4.0"
@@ -3494,20 +3415,10 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
-  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
-
 commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
-
-commander@^8.0.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -3591,18 +3502,6 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-content-disposition@~0.5.2:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
-  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
-  dependencies:
-    safe-buffer "5.2.1"
-
-content-type@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
 convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
@@ -3619,14 +3518,6 @@ cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
-
-cookies@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
-  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
-  dependencies:
-    depd "~2.0.0"
-    keygrip "~1.1.0"
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3892,11 +3783,6 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-unit-converter@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.2.tgz#4c77f5a1954e6dbff60695ecb214e3270436ab21"
-  integrity sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==
-
 css-what@^3.2.1:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
@@ -4036,7 +3922,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.0, debug@^3.1.1, debug@^3.2.7:
+debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -4047,11 +3933,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
-deep-equal@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -4121,11 +4002,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-depd@^2.0.0, depd@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -4352,7 +4228,7 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-encodeurl@^1.0.2, encodeurl@~1.0.2:
+encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
@@ -4439,7 +4315,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -4861,7 +4737,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.7, fast-glob@^3.2.9:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -5068,7 +4944,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fresh@0.5.2, fresh@^0.5.2, fresh@~0.5.2:
+fresh@0.5.2, fresh@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
@@ -5081,15 +4957,6 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
-  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -5099,7 +4966,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
+fs-extra@^9.0.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -5183,11 +5050,6 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -5257,7 +5119,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -5510,11 +5372,6 @@ html-tags@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
   integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
-html-tags@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
-  integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
-
 html-webpack-plugin@^4.5.1:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
@@ -5550,15 +5407,7 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
-http-assert@^1.3.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
-  integrity sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==
-  dependencies:
-    deep-equal "~1.0.1"
-    http-errors "~1.8.0"
-
-http-errors@1.8.1, http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
+http-errors@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
   integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
@@ -5568,16 +5417,6 @@ http-errors@1.8.1, http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
-
-http-errors@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
 
 http-proxy-middleware@^1.0.6:
   version "1.3.1"
@@ -5847,7 +5686,7 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
-is-color-stop@^1.0.0, is-color-stop@^1.1.0:
+is-color-stop@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
   integrity sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=
@@ -5910,7 +5749,7 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
-is-docker@^2.0.0, is-docker@^2.2.1:
+is-docker@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
@@ -5943,13 +5782,6 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
-
-is-generator-function@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
-  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
-  dependencies:
-    has-tostringtag "^1.0.0"
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -6060,11 +5892,6 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
-is-url-superb@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
-  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
-
 is-weakref@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
@@ -6081,13 +5908,6 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
-is-wsl@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
-  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
-  dependencies:
-    is-docker "^2.0.0"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -6224,13 +6044,6 @@ jsonpath-plus@^5.1.0:
   resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz#2fc4b2e461950626c98525425a3a3518b85af6c3"
   integrity sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==
 
-keygrip@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
-  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
-  dependencies:
-    tsscmp "1.0.6"
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -6259,65 +6072,6 @@ klona@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
-
-koa-compose@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
-  integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
-
-koa-convert@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-2.0.0.tgz#86a0c44d81d40551bae22fee6709904573eea4f5"
-  integrity sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==
-  dependencies:
-    co "^4.6.0"
-    koa-compose "^4.1.0"
-
-koa-send@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.1.tgz#39dceebfafb395d0d60beaffba3a70b4f543fe79"
-  integrity sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==
-  dependencies:
-    debug "^4.1.1"
-    http-errors "^1.7.3"
-    resolve-path "^1.4.0"
-
-koa-static@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-5.0.0.tgz#5e92fc96b537ad5219f425319c95b64772776943"
-  integrity sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==
-  dependencies:
-    debug "^3.1.0"
-    koa-send "^5.0.0"
-
-koa@^2.12.0:
-  version "2.13.4"
-  resolved "https://registry.yarnpkg.com/koa/-/koa-2.13.4.tgz#ee5b0cb39e0b8069c38d115139c774833d32462e"
-  integrity sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==
-  dependencies:
-    accepts "^1.3.5"
-    cache-content-type "^1.0.0"
-    content-disposition "~0.5.2"
-    content-type "^1.0.4"
-    cookies "~0.8.0"
-    debug "^4.3.2"
-    delegates "^1.0.0"
-    depd "^2.0.0"
-    destroy "^1.0.4"
-    encodeurl "^1.0.2"
-    escape-html "^1.0.3"
-    fresh "~0.5.2"
-    http-assert "^1.3.0"
-    http-errors "^1.6.3"
-    is-generator-function "^1.0.7"
-    koa-compose "^4.1.0"
-    koa-convert "^2.0.0"
-    on-finished "^2.3.0"
-    only "~0.0.2"
-    parseurl "^1.3.2"
-    statuses "^1.5.0"
-    type-is "^1.6.16"
-    vary "^1.1.2"
 
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
@@ -6470,17 +6224,12 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash.topath@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
-  integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
-
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.15.0, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
+lodash@^4.15.0, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6596,11 +6345,6 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
 mem@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/mem/-/mem-8.1.1.tgz#cf118b357c65ab7b7e0817bdf00c8062297c0122"
@@ -6649,11 +6393,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
-  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
-
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -6694,7 +6433,7 @@ mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
-mime-types@^2.1.18, mime-types@^2.1.19, mime-types@^2.1.27, mime-types@^2.1.30, mime-types@~2.1.24:
+mime-types@^2.1.19, mime-types@^2.1.27, mime-types@^2.1.30, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
@@ -6830,11 +6569,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-modern-normalize@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
-  integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
-
 moment@^2.10.2:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
@@ -6950,13 +6684,6 @@ node-cache@^5.1.2:
   integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
   dependencies:
     clone "2.x"
-
-node-emoji@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
-  integrity sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==
-  dependencies:
-    lodash "^4.17.21"
 
 node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
@@ -7229,19 +6956,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-only@~0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
-  integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
-
-open@^7.0.4:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
-  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
-  dependencies:
-    is-docker "^2.0.0"
-    is-wsl "^2.1.1"
-
 opener@1.5.2, opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
@@ -7382,13 +7096,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parent-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-2.0.0.tgz#fa71f88ff1a50c27e15d8ff74e0e3a9523bf8708"
-  integrity sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==
-  dependencies:
-    callsites "^3.1.0"
-
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
@@ -7446,7 +7153,7 @@ parse-url@^6.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
-parseurl@^1.3.2, parseurl@~1.3.3:
+parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -7484,7 +7191,7 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@1.0.1, path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -7498,11 +7205,6 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
-
-path-to-regexp@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
-  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -7580,15 +7282,6 @@ pnp-webpack-plugin@^1.6.4:
   integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
   dependencies:
     ts-pnp "^1.1.6"
-
-portfinder@^1.0.26:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
-  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
-  dependencies:
-    async "^2.6.2"
-    debug "^3.1.1"
-    mkdirp "^0.5.5"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -7679,13 +7372,6 @@ postcss-custom-media@^7.0.8:
   integrity sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==
   dependencies:
     postcss "^7.0.14"
-
-postcss-custom-properties@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz#f98cd192cd8dfcd8afa3baa1ad5b5d91d01292f3"
-  integrity sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==
-  dependencies:
-    postcss-values-parser "^4.0.0"
 
 postcss-custom-properties@^8.0.11:
   version "8.0.11"
@@ -7824,13 +7510,12 @@ postcss-initial@^3.0.0:
   dependencies:
     postcss "^7.0.2"
 
-postcss-js@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-3.0.3.tgz#2f0bd370a2e8599d45439f6970403b5873abda33"
-  integrity sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==
+postcss-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00"
+  integrity sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==
   dependencies:
     camelcase-css "^2.0.1"
-    postcss "^8.1.6"
 
 postcss-lab-function@^2.0.1:
   version "2.0.1"
@@ -8028,11 +7713,6 @@ postcss-nesting@^7.0.0:
   integrity sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==
   dependencies:
     postcss "^7.0.2"
-
-postcss-nesting@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-8.0.1.tgz#4a8ab3c540a0f138fd3f5d2ee65e4a24d1888024"
-  integrity sha512-cHPNhW5VvRQjszFDxmy16mis9qFQqQLBNw6KVmueLqqE3M182ZAk9+QoxGqbGVryzLVhannw2B5Yhosqq522fA==
 
 postcss-normalize-charset@^4.0.1:
   version "4.0.1"
@@ -8258,7 +7938,7 @@ postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.6:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.8:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz#ee71c3b9ff63d9cd130838876c13a2ec1a992b2f"
   integrity sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
@@ -8305,7 +7985,7 @@ postcss-url@^8.0.0:
     postcss "^7.0.2"
     xxhashjs "^0.2.1"
 
-postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -8324,15 +8004,6 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-values-parser@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz#3b4625e649279613f52842f1c81f2064321beec7"
-  integrity sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==
-  dependencies:
-    color-name "^1.1.4"
-    is-url-superb "^4.0.0"
-    postcss "^7.0.5"
-
 postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
@@ -8341,7 +8012,7 @@ postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17,
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.1.10, postcss@^8.1.6, postcss@^8.2.15, postcss@^8.3.5, postcss@^8.3.7:
+postcss@^8.1.10, postcss@^8.2.15, postcss@^8.4.5:
   version "8.4.5"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
   integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
@@ -8382,11 +8053,6 @@ pretty-error@^2.1.1:
   dependencies:
     lodash "^4.17.20"
     renderkid "^2.0.4"
-
-pretty-hrtime@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
-  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
 pretty-time@^1.1.0:
   version "1.1.0"
@@ -8493,16 +8159,6 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-purgecss@^4.0.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-4.1.3.tgz#683f6a133c8c4de7aa82fe2746d1393b214918f7"
-  integrity sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==
-  dependencies:
-    commander "^8.0.0"
-    glob "^7.1.7"
-    postcss "^8.3.5"
-    postcss-selector-parser "^6.0.6"
 
 pvtsutils@^1.1.2, pvtsutils@^1.2.0, pvtsutils@^1.2.1:
   version "1.2.1"
@@ -8664,14 +8320,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-reduce-css-calc@^2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz#7ef8761a28d614980dc0c982f772c93f7a99de03"
-  integrity sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==
-  dependencies:
-    css-unit-converter "^1.1.1"
-    postcss-value-parser "^3.3.0"
-
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326"
@@ -8769,20 +8417,6 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-replace-in-file@^6.1.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.2.tgz#0f19835137177c89932f45df319f3539a019484f"
-  integrity sha512-Dbt5pXKvFVPL3WAaEB3ZX+95yP0CeAtIPJDwYzHbPP5EAHn+0UoegH/Wg3HKflU9dYBH8UnBC2NvY3P+9EZtTg==
-  dependencies:
-    chalk "^4.1.2"
-    glob "^7.2.0"
-    yargs "^17.2.1"
-
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -8798,25 +8432,12 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve-from@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
-  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-path@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
-  integrity sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=
-  dependencies:
-    http-errors "~1.6.2"
-    path-is-absolute "1.0.1"
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.14.2, resolve@^1.2.0, resolve@^1.20.0:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.14.2, resolve@^1.2.0, resolve@^1.20.0, resolve@^1.21.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -8865,7 +8486,7 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -8911,7 +8532,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -9095,11 +8716,6 @@ setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
-
-setprototypeof@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
-  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -9354,7 +8970,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0, statuses@~1.5.0:
+"statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -9417,7 +9033,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9566,57 +9182,31 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-tailwind-config-viewer@^1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/tailwind-config-viewer/-/tailwind-config-viewer-1.6.3.tgz#cbd6ba6d4a6f063bb5023261dfaf3c05358cf8ba"
-  integrity sha512-XesuasyVLDXadHhLLDeS0H5EiAhhWnRPDjDRsP4sYRXGn8h7Vgnv9TzFXvoaNG6dvuRuwWQxJRfNOjaWid2V1g==
-  dependencies:
-    "@koa/router" "^9.0.1"
-    commander "^6.0.0"
-    fs-extra "^9.0.1"
-    koa "^2.12.0"
-    koa-static "^5.0.0"
-    open "^7.0.4"
-    portfinder "^1.0.26"
-    replace-in-file "^6.1.0"
-
-tailwindcss@^2.2.2:
-  version "2.2.19"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-2.2.19.tgz#540e464832cd462bb9649c1484b0a38315c2653c"
-  integrity sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==
+tailwindcss@^3.0.17:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.0.17.tgz#2c5fe6c364d76ec54644347c6f09befe0113b06f"
+  integrity sha512-OiHUsmOKQQEg/ocXaLIjk/kOz8EK2jF6iPuc1bQ4NsmhYl7sk70UDsGV02AJvBAAiJhinPCkDR8egT9qY+ulCw==
   dependencies:
     arg "^5.0.1"
-    bytes "^3.0.0"
     chalk "^4.1.2"
-    chokidar "^3.5.2"
-    color "^4.0.1"
+    chokidar "^3.5.3"
+    color-name "^1.1.4"
     cosmiconfig "^7.0.1"
     detective "^5.2.0"
     didyoumean "^1.2.2"
     dlv "^1.1.3"
-    fast-glob "^3.2.7"
-    fs-extra "^10.0.0"
-    glob-parent "^6.0.1"
-    html-tags "^3.1.0"
-    is-color-stop "^1.1.0"
-    is-glob "^4.0.1"
-    lodash "^4.17.21"
-    lodash.topath "^4.5.2"
-    modern-normalize "^1.1.0"
-    node-emoji "^1.11.0"
+    fast-glob "^3.2.11"
+    glob-parent "^6.0.2"
+    is-glob "^4.0.3"
     normalize-path "^3.0.0"
     object-hash "^2.2.0"
-    postcss-js "^3.0.3"
+    postcss-js "^4.0.0"
     postcss-load-config "^3.1.0"
     postcss-nested "5.0.6"
-    postcss-selector-parser "^6.0.6"
-    postcss-value-parser "^4.1.0"
-    pretty-hrtime "^1.0.3"
-    purgecss "^4.0.3"
+    postcss-selector-parser "^6.0.8"
+    postcss-value-parser "^4.2.0"
     quick-lru "^5.1.1"
-    reduce-css-calc "^2.1.8"
-    resolve "^1.20.0"
-    tmp "^0.2.1"
+    resolve "^1.21.0"
 
 tapable@^1.0.0, tapable@^1.0.0-beta.5, tapable@^1.1.3:
   version "1.1.3"
@@ -9746,13 +9336,6 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
-  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
-  dependencies:
-    rimraf "^3.0.0"
-
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -9846,11 +9429,6 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tsscmp@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
-  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
-
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -9890,14 +9468,6 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-is@^1.6.16:
-  version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
-  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.24"
-
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -9913,7 +9483,7 @@ ua-parser-js@^0.7.28:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
 
-ufo@^0.7.4, ufo@^0.7.5, ufo@^0.7.9:
+ufo@^0.7.4, ufo@^0.7.9:
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.9.tgz#0268e3734b413c9ed6f3510201f42372821b875c"
   integrity sha512-6t9LrLk3FhqTS+GW3IqlITtfRB5JAVr5MMNjpBECfK827W+Vh5Ilw/LhTcHWrt6b3hkeBvcbjx4Ti7QVFzmcww==
@@ -10575,11 +10145,6 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -10599,29 +10164,6 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yargs-parser@^21.0.0:
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
-  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
-
-yargs@^17.2.1:
-  version "17.3.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
-  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.0.0"
-
-ylru@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
-  integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Replaces the (not often updated) nuxt-tailwind module with "normal" tailwind as in https://tailwindcss.com/docs/guides/nuxtjs.

Also resets prettier config to default, and applies the defauly style to all code.