### PR TITLE
Show export error message in toast

### DIFF
--- a/components/PatientRecordManageMenu.vue
+++ b/components/PatientRecordManageMenu.vue
@@ -139,12 +139,13 @@ export default defineComponent({
       });
     }
 
-    function showExportErrorToast() {
+    function showExportErrorToast(e: Error) {
+      console.log(e);
       // Notify of task finished
       $toast.show({
         type: "error",
         title: "Export Failed",
-        message: "Export failed",
+        message: e.message,
         timeout: 10,
         classTimeout: "bg-red-600",
       });
@@ -160,8 +161,8 @@ export default defineComponent({
             .then(() => {
               showExportSuccessToast();
             })
-            .catch(() => {
-              showExportErrorToast();
+            .catch((e) => {
+              showExportErrorToast(e);
             });
         })
         .finally(() => {
@@ -179,8 +180,8 @@ export default defineComponent({
             .then(() => {
               showExportSuccessToast();
             })
-            .catch(() => {
-              showExportErrorToast();
+            .catch((e) => {
+              showExportErrorToast(e);
             });
         })
         .finally(() => {
@@ -198,8 +199,8 @@ export default defineComponent({
             .then(() => {
               showExportSuccessToast();
             })
-            .catch(() => {
-              showExportErrorToast();
+            .catch((e) => {
+              showExportErrorToast(e);
             });
         })
         .finally(() => {
@@ -217,8 +218,8 @@ export default defineComponent({
             .then(() => {
               showExportSuccessToast();
             })
-            .catch(() => {
-              showExportErrorToast();
+            .catch((e) => {
+              showExportErrorToast(e);
             });
         })
         .finally(() => {
@@ -236,8 +237,8 @@ export default defineComponent({
             .then(() => {
               showExportSuccessToast();
             })
-            .catch(() => {
-              showExportErrorToast();
+            .catch((e) => {
+              showExportErrorToast(e);
             });
         })
         .finally(() => {

--- a/components/PatientRecordManageMenu.vue
+++ b/components/PatientRecordManageMenu.vue
@@ -143,7 +143,7 @@ export default defineComponent({
       console.log(e);
       // Notify of task finished
       $toast.show({
-        type: "error",
+        type: "danger",
         title: "Export Failed",
         message: e.message,
         timeout: 10,

--- a/components/PatientRecordMembershipsMenu.vue
+++ b/components/PatientRecordMembershipsMenu.vue
@@ -119,7 +119,7 @@ export default defineComponent({
         .catch((error) => {
           // Notify of task error
           $toast.show({
-            type: "error",
+            type: "danger",
             title: "Error creating PKB membership",
             message: error.response.data.detail,
             timeout: 10,

--- a/composables/useTasks.ts
+++ b/composables/useTasks.ts
@@ -1,4 +1,5 @@
 import { PageTrackableTaskSchema, TrackableTaskSchema } from "@ukkidney/ukrdc-axios-ts";
+
 import useApi from "./useApi";
 
 export default function () {

--- a/pages/patientrecords/_pid/update/demographics.vue
+++ b/pages/patientrecords/_pid/update/demographics.vue
@@ -384,7 +384,7 @@ export default defineComponent({
         })
         .catch((error) => {
           $toast.show({
-            type: "error",
+            type: "danger",
             title: "Error",
             message: "Failed to update record demographics",
             timeout: 10,


### PR DESCRIPTION
Adds the specific export error message to the error toast, to help debug errors. Also corrects the toast type for error/danger states.