### PR TITLE
Added multi-stage loading text to stats plots

### DIFF
--- a/components/AdministratorDashboard.vue
+++ b/components/AdministratorDashboard.vue
@@ -68,7 +68,7 @@ Admin (permission ukrdc:facilities:*) dashboard with overview of all facilities.
           hovertemplate="<b>%{x}</b><br>New errors: %{y}<extra></extra>"
           @click="errorHistoryPointClickHandler"
         />
-        <BaseSkeleImage v-else class="h-64 w-full" />
+        <BaseSkeleDiv v-else class="h-64 w-full" />
       </BaseCard>
       <!-- WorkItems history -->
       <BaseCard>
@@ -85,7 +85,7 @@ Admin (permission ukrdc:facilities:*) dashboard with overview of all facilities.
           hovertemplate="<b>%{x}</b><br>New work items: %{y}<extra></extra>"
           @click="workitemHistoryPointClickHandler"
         />
-        <BaseSkeleImage v-else class="h-64 w-full" />
+        <BaseSkeleDiv v-else class="h-64 w-full" />
       </BaseCard>
     </div>
   </div>
@@ -99,7 +99,7 @@ import { PlotDatum } from "plotly.js";
 import BaseCard from "~/components/base/BaseCard.vue";
 import BaseCardFooter from "~/components/base/BaseCardFooter.vue";
 import BaseCardHeader from "~/components/base/BaseCardHeader.vue";
-import BaseSkeleImage from "~/components/base/BaseSkeleImage.vue";
+import BaseSkeleDiv from "~/components/base/BaseSkeleDiv.vue";
 import BaseSkeleText from "~/components/base/BaseSkeleText.vue";
 import IconExclamationTriangle from "~/components/icons/hero/24/outline/IconExclamationTriangle.vue";
 import IconLink from "~/components/icons/hero/24/outline/IconLink.vue";
@@ -114,7 +114,7 @@ export default defineComponent({
     BaseCardHeader,
     BaseCardFooter,
     BaseSkeleText,
-    BaseSkeleImage,
+    BaseSkeleDiv,
     IconExclamationTriangle,
     IconLink,
     IconUsers,

--- a/components/FacilityErrorsHistoryPlot.vue
+++ b/components/FacilityErrorsHistoryPlot.vue
@@ -9,7 +9,7 @@
       hovertemplate="<b>%{x}</b><br>New errors: %{y}<extra></extra>"
       @click="historyPointClickHandler"
     />
-    <BaseSkeleImage v-else class="h-64 w-full" />
+    <BaseSkeleDiv v-else class="h-64 w-full" />
   </div>
 </template>
 
@@ -18,7 +18,7 @@ import { computed, defineComponent, onMounted, ref, useRouter } from "@nuxtjs/co
 import { FacilityDetailsSchema, HistoryPoint } from "@ukkidney/ukrdc-axios-ts";
 import { PlotDatum } from "plotly.js";
 
-import BaseSkeleImage from "~/components/base/BaseSkeleImage.vue";
+import BaseSkeleDiv from "~/components/base/BaseSkeleDiv.vue";
 import BaseTimeSeriesLinePlot from "~/components/plots/base/BaseTimeSeriesLinePlot.vue";
 import useApi from "~/composables/useApi";
 import { getPointDateRange, unpackHistoryPoints } from "~/helpers/chartUtils";
@@ -26,7 +26,7 @@ import { getPointDateRange, unpackHistoryPoints } from "~/helpers/chartUtils";
 export default defineComponent({
   components: {
     BaseTimeSeriesLinePlot,
-    BaseSkeleImage,
+    BaseSkeleDiv,
   },
   props: {
     facility: {

--- a/components/base/BaseSkeleDiv.vue
+++ b/components/base/BaseSkeleDiv.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="animate-pulse bg-gray-200"><slot /></div>
+</template>

--- a/components/base/BaseSkeleImage.vue
+++ b/components/base/BaseSkeleImage.vue
@@ -1,3 +1,0 @@
-<template>
-  <div class="animate-pulse bg-gray-200"></div>
-</template>

--- a/components/plots/stats/Labelled2dBarPlot.vue
+++ b/components/plots/stats/Labelled2dBarPlot.vue
@@ -26,7 +26,7 @@
       :orientation="orientation"
       class="m-2 h-72"
     />
-    <BaseSkeleImage v-else class="h-72 w-full" />
+    <SkelePlot v-else />
   </BaseCard>
 </template>
 
@@ -37,9 +37,9 @@ import { Labelled2d } from "@ukkidney/ukrdc-axios-ts";
 import BaseButtonMini from "~/components/base/BaseButtonMini.vue";
 import BaseCard from "~/components/base/BaseCard.vue";
 import BaseCardHeader from "~/components/base/BaseCardHeader.vue";
-import BaseSkeleImage from "~/components/base/BaseSkeleImage.vue";
 import BaseBarPlot from "~/components/plots/base/BaseBarPlot.vue";
 import BaseMarkdownDescriptionTooltip from "~/components/plots/stats/BaseMarkdownDescriptionTooltip.vue";
+import SkelePlot from "~/components/plots/stats/SkelePlot.vue";
 import { buildCsv } from "~/helpers/exportUtils";
 import { saveAs } from "~/helpers/fileUtils";
 
@@ -49,7 +49,7 @@ export default defineComponent({
     BaseBarPlot,
     BaseCard,
     BaseCardHeader,
-    BaseSkeleImage,
+    SkelePlot,
     BaseMarkdownDescriptionTooltip,
   },
   props: {

--- a/components/plots/stats/Labelled2dPiePlot.vue
+++ b/components/plots/stats/Labelled2dPiePlot.vue
@@ -14,7 +14,7 @@
       <BaseButtonMini v-if="labelled2d" @click="exportData">Export</BaseButtonMini>
     </BaseCardHeader>
     <BasePiePlot v-if="labelled2d" :id="id" :x="labelled2d.data.x" :y="labelled2d.data.y" class="h-72" />
-    <BaseSkeleImage v-else class="h-72 w-full" />
+    <SkelePlot v-else />
   </BaseCard>
 </template>
 
@@ -25,9 +25,9 @@ import { Labelled2d } from "@ukkidney/ukrdc-axios-ts";
 import BaseButtonMini from "~/components/base/BaseButtonMini.vue";
 import BaseCard from "~/components/base/BaseCard.vue";
 import BaseCardHeader from "~/components/base/BaseCardHeader.vue";
-import BaseSkeleImage from "~/components/base/BaseSkeleImage.vue";
 import BasePiePlot from "~/components/plots/base/BasePiePlot.vue";
 import BaseMarkdownDescriptionTooltip from "~/components/plots/stats/BaseMarkdownDescriptionTooltip.vue";
+import SkelePlot from "~/components/plots/stats/SkelePlot.vue";
 import { buildCsv } from "~/helpers/exportUtils";
 import { saveAs } from "~/helpers/fileUtils";
 
@@ -37,7 +37,7 @@ export default defineComponent({
     BasePiePlot,
     BaseCard,
     BaseCardHeader,
-    BaseSkeleImage,
+    SkelePlot,
     BaseMarkdownDescriptionTooltip,
   },
   props: {

--- a/components/plots/stats/LabelledNetworkSankeyPlot.vue
+++ b/components/plots/stats/LabelledNetworkSankeyPlot.vue
@@ -23,20 +23,20 @@
       :link="labelledNetwork.link"
       class="h-72"
     />
-    <BaseSkeleImage v-else class="h-72 w-full" />
+    <SkelePlot v-else />
   </BaseCard>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "@nuxtjs/composition-api";
+import { defineComponent, onMounted } from "@nuxtjs/composition-api";
 import { LabelledNetwork } from "@ukkidney/ukrdc-axios-ts";
 
 import BaseButtonMini from "~/components/base/BaseButtonMini.vue";
 import BaseCard from "~/components/base/BaseCard.vue";
 import BaseCardHeader from "~/components/base/BaseCardHeader.vue";
-import BaseSkeleImage from "~/components/base/BaseSkeleImage.vue";
 import BaseSankeyPlot from "~/components/plots/base/BaseSankeyPlot.vue";
 import BaseMarkdownDescriptionTooltip from "~/components/plots/stats/BaseMarkdownDescriptionTooltip.vue";
+import SkelePlot from "~/components/plots/stats/SkelePlot.vue";
 import { saveAs } from "~/helpers/fileUtils";
 
 export default defineComponent({
@@ -45,7 +45,7 @@ export default defineComponent({
     BaseSankeyPlot,
     BaseCard,
     BaseCardHeader,
-    BaseSkeleImage,
+    SkelePlot,
     BaseMarkdownDescriptionTooltip,
   },
   props: {
@@ -80,6 +80,8 @@ export default defineComponent({
       const blob = new Blob([JSON.stringify(exportJSON)], { type: "text/plain;charset=utf-8" });
       saveAs(blob, `${props.exportFileName}.json`);
     }
+
+    onMounted(() => {});
 
     return {
       exportData,

--- a/components/plots/stats/SkelePlot.vue
+++ b/components/plots/stats/SkelePlot.vue
@@ -1,0 +1,41 @@
+<!-- eslint-disable vue/no-v-html -->
+<template>
+  <BaseSkeleDiv class="h-72 w-full">
+    <div class="flex h-full w-full flex-col items-center justify-center">
+      <p>{{ loadingText }}</p>
+    </div>
+  </BaseSkeleDiv>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+
+import BaseSkeleDiv from "~/components/base/BaseSkeleDiv.vue";
+import useTimer from "~/composables/useTimer";
+
+export default defineComponent({
+  components: {
+    BaseSkeleDiv,
+  },
+  setup() {
+    const { timeSinceMount } = useTimer();
+
+    const loadingText = computed<string>(() => {
+      if (timeSinceMount.value >= 30) {
+        return "An internal error may have occurred. Please try again later.";
+      }
+      if (timeSinceMount.value >= 10) {
+        return "Calculations are taking longer than usual...";
+      }
+      if (timeSinceMount.value >= 1) {
+        return "Calculating...";
+      }
+      return "";
+    });
+
+    return {
+      loadingText,
+    };
+  },
+});
+</script>

--- a/composables/useTimer.ts
+++ b/composables/useTimer.ts
@@ -1,0 +1,22 @@
+import { onMounted, onUnmounted, ref } from "@nuxtjs/composition-api";
+
+export default function () {
+  const timeSinceMount = ref(0);
+
+  const timer = undefined;
+
+  onUnmounted(() => {
+    clearInterval(timer);
+  });
+
+  onMounted(() => {
+    timeSinceMount.value = 0;
+    setInterval(() => {
+      timeSinceMount.value++;
+    }, 1000);
+  });
+
+  return {
+    timeSinceMount,
+  };
+}


### PR DESCRIPTION
Adds loading text to stats plots.

Up to 1 second, no loading message is shown (placeholder only)
1 - 10 seconds: "Calculating..."
10 - 30 seconds: "Calculations are taking longer than usual..."
\> 30 seconds: "An internal error may have occurred. Please try again later."