### PR TITLE
Authentication flow improvements

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -45,7 +45,12 @@ export default function () {
   });
 
   // Request interceptor to handle API base paths and authentication
-  apiInstance.interceptors.request.use((config) => {
+  apiInstance.interceptors.request.use(async (config) => {
+    // If auth has expired, reauthenticate before proceeding with the API request
+    if (!$okta.isAuthenticated) {
+      await $okta.signInAuto();
+    }
+
     // Add the authorization header to each request
     const token = $okta.getAccessToken();
     if (config.headers === undefined) {

--- a/modules/okta-auth/src/plugin.client.js
+++ b/modules/okta-auth/src/plugin.client.js
@@ -108,18 +108,6 @@ const oktaPlugin = (_ctx, inject) => {
     next();
   });
 
-  // Handle onAuthExpired
-  if (configOptions.authExpiredRedirectUri) {
-    oktaAuth.authStateManager.subscribe((authState) => {
-      if (!authState.isAuthenticated) {
-        // Store the current route
-        oktaAuth.setOriginalUri(router.currentRoute.fullPath);
-        // Redirect to the authExpiredRedirectUri
-        _ctx.redirect(configOptions.authExpiredRedirectUri);
-      }
-    });
-  }
-
   // Start the auth background service
   oktaAuth.start();
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -111,7 +111,6 @@ export default {
     defaultProtectRoutes: true,
     redirectUri: "/login",
     postLogoutRedirectUri: "/login",
-    authExpiredRedirectUri: "/login",
     responseType: "code",
     pkce: true,
     scopes: ["openid", "profile", "email", "offline_access"],


### PR DESCRIPTION
Aims to resolve the long-standing issue of fresh logins getting stuck on the "Signing you in" page.

## Notes

### `oktaAuth.authStateManager.subscribe`

We used to have a bit of code in the auth plugin that subscribed to changes in the auth state, and if the change was to become unauthenticated (e.g. token expiry while on a page), it would trigger a login.

The issue here is that the first time you open a page, that auth state watcher gets triggered. So, if you're logged out and navigate to any page, the navigation guard begins an auth flow, and while that's happening the subscription _also_ triggers an auth flow. The subscription call happens after the nav guard, so the `originalUri` gets overwritten as `/` or `/login` meaning that once the auth flow has completed, the user is redirected to the wrong page. Usually, the original URL was set by the subscription to `/login` meaning the user just sits on the login page without redirection working.

**The key change here is removing that auth state watcher, and relying more on the navigation guard to ensure auth. However, we still need to handle the case that auth expires while the user is already on a page. See below.**

### `apiInstance.interceptors.request`

As described above, it's possible for the following to happen:

* User navigates to a page, nav guard ensure the user is authenticated
* User sits on that page for some time, and auth expires
* Without navigating away from that page, the user makes a new API call
* Auth has expired, so API call fails

Previously, the auth state watcher would kick the user out to the login page as soon as the token expires, however this has been causing problems so has been removed, see above.

We now instead use the API request interceptor that injects auth tokens to _also_ check for authentication. The above timeline now goes something like:

* User navigates to a page, nav guard ensure the user is authenticated
* User sits on that page for some time, and auth expires
* Without navigating away from that page, the user makes a new API call
* API request interceptor checks auth, finds it has expired, and starts the re-authentication process
* User authenticates, callback takes them back to the page they were on